### PR TITLE
Fix export:pdf by composing the transport environment

### DIFF
--- a/bake/presently/export.rb
+++ b/bake/presently/export.rb
@@ -55,12 +55,9 @@ def pdf(output: "presentation.pdf", slides_root: "slides", notes: true, speaker:
 				endpoint: Async::HTTP::Endpoint.parse("http://localhost", bound_endpoint)
 			)
 			
-			# `make_server` comes from `Falcon::Environment::Server`, which
-			# `Lively::Environment::Application` does not include directly - the
-			# transport is composed in via `transport_environment` so that
-			# `service_class` resolves correctly. Compose it here too, otherwise
-			# the evaluator has no `make_server`.
-			transport = environment.with(environment.evaluator.transport_environment)
+			# PDF export always requires an HTTP server, regardless of the configured
+			# Lively transport:
+			transport = environment.with(environment.evaluator.http_environment)
 			evaluator = transport.evaluator
 			server = evaluator.make_server(evaluator.endpoint)
 			server_task = task.async{server.run}

--- a/bake/presently/export.rb
+++ b/bake/presently/export.rb
@@ -55,7 +55,13 @@ def pdf(output: "presentation.pdf", slides_root: "slides", notes: true, speaker:
 				endpoint: Async::HTTP::Endpoint.parse("http://localhost", bound_endpoint)
 			)
 			
-			evaluator = environment.evaluator
+			# `make_server` comes from `Falcon::Environment::Server`, which
+			# `Lively::Environment::Application` does not include directly - the
+			# transport is composed in via `transport_environment` so that
+			# `service_class` resolves correctly. Compose it here too, otherwise
+			# the evaluator has no `make_server`.
+			transport = environment.with(environment.evaluator.transport_environment)
+			evaluator = transport.evaluator
 			server = evaluator.make_server(evaluator.endpoint)
 			server_task = task.async{server.run}
 			

--- a/presently.gemspec
+++ b/presently.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |spec|
 	
 	spec.required_ruby_version = ">= 3.3"
 	
-	spec.add_dependency "lively", "~> 0.16"
+	spec.add_dependency "lively", "~> 0.18"
 	spec.add_dependency "markly", "~> 0.16"
 	spec.add_dependency "async-webdriver", "~> 0.12"
 end

--- a/test/presently/environment/application.rb
+++ b/test/presently/environment/application.rb
@@ -16,29 +16,29 @@ describe Presently::Environment::Application do
 			endpoint: Async::HTTP::Endpoint.parse("http://localhost:0")
 		)
 	end
-
+	
 	it "exposes the presently application" do
 		expect(environment.evaluator.application).to be == Presently::Application
 	end
-
+	
 	# `make_server` comes from `Falcon::Environment::Server`, which this module
 	# does not include directly. Anything wanting to run a server (e.g. the
-	# `presently:export:pdf` task) has to compose the transport first.
+	# `presently:export:pdf` task) has to compose the HTTP environment first.
 	it "does not expose make_server before the transport is composed" do
 		expect(environment.evaluator.respond_to?(:make_server)).to be == false
 	end
-
-	it "exposes make_server once the transport environment is composed" do
+	
+	it "exposes make_server once the HTTP environment is composed" do
 		evaluator = environment.evaluator
-		transport = environment.with(evaluator.transport_environment)
-
+		transport = environment.with(evaluator.http_environment)
+		
 		expect(transport.evaluator.respond_to?(:make_server)).to be == true
 	end
-
-	it "can build a server from the composed transport environment" do
-		transport = environment.with(environment.evaluator.transport_environment)
+	
+	it "can build a server from the composed HTTP environment" do
+		transport = environment.with(environment.evaluator.http_environment)
 		evaluator = transport.evaluator
-
+		
 		expect(evaluator.make_server(evaluator.endpoint)).not.to be_nil
 	end
 end

--- a/test/presently/environment/application.rb
+++ b/test/presently/environment/application.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+# Released under the MIT License.
+# Copyright, 2026, by Samuel Williams.
+
+require "presently/environment/application"
+require "async/service/environment"
+require "async/http/endpoint"
+
+describe Presently::Environment::Application do
+	let(:environment) do
+		Async::Service::Environment.build(
+			Presently::Environment::Application,
+			root: Dir.pwd,
+			slides_root: "slides",
+			endpoint: Async::HTTP::Endpoint.parse("http://localhost:0")
+		)
+	end
+
+	it "exposes the presently application" do
+		expect(environment.evaluator.application).to be == Presently::Application
+	end
+
+	# `make_server` comes from `Falcon::Environment::Server`, which this module
+	# does not include directly. Anything wanting to run a server (e.g. the
+	# `presently:export:pdf` task) has to compose the transport first.
+	it "does not expose make_server before the transport is composed" do
+		expect(environment.evaluator.respond_to?(:make_server)).to be == false
+	end
+
+	it "exposes make_server once the transport environment is composed" do
+		evaluator = environment.evaluator
+		transport = environment.with(evaluator.transport_environment)
+
+		expect(transport.evaluator.respond_to?(:make_server)).to be == true
+	end
+
+	it "can build a server from the composed transport environment" do
+		transport = environment.with(environment.evaluator.transport_environment)
+		evaluator = transport.evaluator
+
+		expect(evaluator.make_server(evaluator.endpoint)).not.to be_nil
+	end
+end


### PR DESCRIPTION
`bake presently:export:pdf` currently fails immediately:

```
NoMethodError: undefined method 'make_server' for an instance of #<Class:0x...>
Did you mean?  make_service
    presently-0.14.1/bake/presently/export.rb:59:in 'block in pdf'
```

`make_server` is defined in `Falcon::Environment::Server`, and
`Lively::Environment::Application` deliberately doesn't include that — there's a
comment in `lively/environment/application.rb` explaining why:

> Note: does not include `Falcon::Environment::Server` directly. Falcon is
> brought in exclusively via `http_environment` so that the combined evaluator's
> `service_class` resolves correctly without shadowing.

So the bare application evaluator has no `make_server`. This composes the
transport environment first, the same way `Lively::Environment::Application#make_service`
does, and takes the evaluator from that.

### Verification

Tested against a real 62-slide deck:

```
$ bundle exec bake presently:export:pdf --output out.pdf --notes false --speaker false --timing false
$ # 62 pages, MediaBox 1440x810pt = 50.8x28.6cm, 16:9
```

I'm giving a talk at COSCUP with `presently` right now, so this was the export path I
needed. Thanks for the tool, it's been a pleasure to write in.
