### PR TITLE
Document PDF page size conversions

### DIFF
--- a/lib/presently/export.rb
+++ b/lib/presently/export.rb
@@ -20,8 +20,16 @@ module Presently
 		PageSize = Struct.new(:slide_width_px, :slide_height_px, :notes_height_px, keyword_init: true) do
 			PX_PER_CM = 96.0 / 2.54
 			
+			# Convert the slide width from CSS pixels to centimetres.
+			# @returns [Float] The slide width in centimetres.
 			def slide_width_cm  = (slide_width_px  / PX_PER_CM).round(4)
+			
+			# Convert the slide height from CSS pixels to centimetres.
+			# @returns [Float] The slide height in centimetres.
 			def slide_height_cm = (slide_height_px / PX_PER_CM).round(4)
+			
+			# Convert the notes panel height from CSS pixels to centimetres.
+			# @returns [Float] The notes panel height in centimetres.
 			def notes_height_cm = (notes_height_px / PX_PER_CM).round(4)
 		end
 		


### PR DESCRIPTION
The latest documentation coverage check recognizes the three `PageSize` conversion helpers as public methods. Document each helper and its return type so documentation coverage returns to 100%.

Verification:
- `bundle exec rubocop`
- `bundle exec bake decode:index:coverage lib` (129/129)
- `bundle exec sus` (110 tests)