### PR TITLE
Add nested slide directory support

### DIFF
--- a/bake/presently/rehearse.rb
+++ b/bake/presently/rehearse.rb
@@ -31,12 +31,12 @@ def rehearse(slides_root: "slides", speaker: nil, from: nil, to: nil, resume: fa
 	slides = slides.select{|slide| slide.speaker == speaker} if speaker
 	
 	if from
-		start_index = slides.index{|slide| slide.relative_path.include?(from)}
+		start_index = slides.index{|slide| slide.path.include?(from)}
 		slides = slides[start_index..] if start_index
 	end
 	
 	if to
-		end_index = slides.index{|slide| slide.relative_path.include?(to)}
+		end_index = slides.index{|slide| slide.path.include?(to)}
 		slides = slides[..end_index] if end_index
 	end
 	
@@ -49,7 +49,7 @@ def rehearse(slides_root: "slides", speaker: nil, from: nil, to: nil, resume: fa
 		
 		prior_records = JSON.parse(File.read(log), symbolize_names: true)
 		last_path = prior_records.last&.dig(:path)
-		resume_index = slides.index{|slide| slide.relative_path == last_path}
+		resume_index = slides.index{|slide| slide.path == last_path}
 		
 		if resume_index.nil?
 			puts "Last rehearsed slide (#{last_path}) not found in current slide set. Nothing to resume."
@@ -81,7 +81,7 @@ def rehearse(slides_root: "slides", speaker: nil, from: nil, to: nil, resume: fa
 	records = []
 	offset = prior_records.length
 	slides.each_with_index do |slide, index|
-		relative_path = slide.relative_path
+		relative_path = slide.path
 		headline = extract_headline(slide)
 		absolute = offset + index + 1
 		total = offset + slides.length

--- a/bake/presently/rehearse.rb
+++ b/bake/presently/rehearse.rb
@@ -21,8 +21,8 @@ end
 #
 # @parameter slides_root [String] The slides directory. Default: `slides`.
 # @parameter speaker [String | Nil] Only rehearse slides for this speaker.
-# @parameter from [String | Nil] Substring match — start at the first slide whose filename contains this.
-# @parameter to [String | Nil] Substring match — stop after the first slide whose filename contains this.
+# @parameter from [String | Nil] Substring match — start at the first slide whose relative path contains this.
+# @parameter to [String | Nil] Substring match — stop after the first slide whose relative path contains this.
 # @parameter resume [Boolean] Resume from the slide after the last one recorded in the log. Keeps prior records and appends new ones.
 # @parameter log [String] Path to write the JSON log. Default: `tmp/rehearsal.json`.
 def rehearse(slides_root: "slides", speaker: nil, from: nil, to: nil, resume: false, log: "tmp/rehearsal.json")
@@ -31,12 +31,12 @@ def rehearse(slides_root: "slides", speaker: nil, from: nil, to: nil, resume: fa
 	slides = slides.select{|slide| slide.speaker == speaker} if speaker
 	
 	if from
-		start_index = slides.index{|slide| File.basename(slide.path).include?(from)}
+		start_index = slides.index{|slide| slide.relative_path.include?(from)}
 		slides = slides[start_index..] if start_index
 	end
 	
 	if to
-		end_index = slides.index{|slide| File.basename(slide.path).include?(to)}
+		end_index = slides.index{|slide| slide.relative_path.include?(to)}
 		slides = slides[..end_index] if end_index
 	end
 	
@@ -49,7 +49,7 @@ def rehearse(slides_root: "slides", speaker: nil, from: nil, to: nil, resume: fa
 		
 		prior_records = JSON.parse(File.read(log), symbolize_names: true)
 		last_path = prior_records.last&.dig(:path)
-		resume_index = slides.index{|slide| File.basename(slide.path) == last_path}
+		resume_index = slides.index{|slide| slide.relative_path == last_path}
 		
 		if resume_index.nil?
 			puts "Last rehearsed slide (#{last_path}) not found in current slide set. Nothing to resume."
@@ -81,14 +81,14 @@ def rehearse(slides_root: "slides", speaker: nil, from: nil, to: nil, resume: fa
 	records = []
 	offset = prior_records.length
 	slides.each_with_index do |slide, index|
-		basename = File.basename(slide.path)
+		relative_path = slide.relative_path
 		headline = extract_headline(slide)
 		absolute = offset + index + 1
 		total = offset + slides.length
 		
 		puts
 		puts "─" * 72
-		puts "[#{absolute}/#{total}] #{basename}  planned: #{format_duration(slide.duration)}  speaker: #{slide.speaker || "—"}"
+		puts "[#{absolute}/#{total}] #{relative_path}  planned: #{format_duration(slide.duration)}  speaker: #{slide.speaker || "—"}"
 		puts "  #{headline}" unless headline.empty?
 		if slide.notes
 			notes = slide.notes.to_commonmark.strip
@@ -105,7 +105,7 @@ def rehearse(slides_root: "slides", speaker: nil, from: nil, to: nil, resume: fa
 		
 		records << {
 			index: absolute,
-			path: basename,
+			path: relative_path,
 			speaker: slide.speaker,
 			planned: slide.duration,
 			actual: elapsed.round(1),

--- a/bake/presently/slides.rb
+++ b/bake/presently/slides.rb
@@ -24,7 +24,7 @@ def notes(slides_root: "slides")
 	presentation.slides.each do |slide|
 		next unless slide.notes
 		
-		puts "## #{slide.relative_path}"
+		puts "## #{slide.path}"
 		puts
 		puts slide.notes.to_commonmark
 		puts
@@ -58,7 +58,7 @@ def speakers(slides_root: "slides")
 		puts "#{speaker} — #{format_duration(total_seconds)}"
 		
 		slides.each do |slide|
-			puts "  #{format_duration(slide.duration)}  #{slide.title}  (#{slide.relative_path})"
+			puts "  #{format_duration(slide.duration)}  #{slide.title}  (#{slide.path})"
 		end
 		
 		puts

--- a/bake/presently/slides.rb
+++ b/bake/presently/slides.rb
@@ -24,7 +24,7 @@ def notes(slides_root: "slides")
 	presentation.slides.each do |slide|
 		next unless slide.notes
 		
-		puts "## #{slide.path}"
+		puts "## #{slide.relative_path}"
 		puts
 		puts slide.notes.to_commonmark
 		puts
@@ -58,7 +58,7 @@ def speakers(slides_root: "slides")
 		puts "#{speaker} — #{format_duration(total_seconds)}"
 		
 		slides.each do |slide|
-			puts "  #{format_duration(slide.duration)}  #{slide.title}  (#{File.basename(slide.path)})"
+			puts "  #{format_duration(slide.duration)}  #{slide.title}  (#{slide.relative_path})"
 		end
 		
 		puts
@@ -69,9 +69,10 @@ end
 
 # Renumber slide files sequentially with a consistent step size.
 #
-# Renames all `.md` files in the slides directory to have sequential
+# Renames all `.md` files directly in the given directory to have sequential
 # numeric prefixes (010, 020, 030, ...), preserving their current order.
-# The descriptive part of the filename (after the number prefix) is kept.
+# The descriptive part of the filename (after the number prefix) is kept. It
+# does not recurse; pass a nested directory as `slides_root` to renumber it.
 #
 # @parameter slides_root [String] The slides directory. Default: `slides`.
 # @parameter step [Integer] The step between slide numbers. Default: `10`.

--- a/context/getting-started.md
+++ b/context/getting-started.md
@@ -32,7 +32,27 @@ $ mkdir slides
 
 ### Writing Slides
 
-Each slide is a Markdown file in the `slides/` directory. Files are ordered alphabetically, so prefix them with numbers:
+Each slide is a Markdown file in the `slides/` directory. Files are ordered by path, and every directory and slide filename must begin with a numeric prefix:
+
+``` text
+slides/
+├── 010-welcome.md
+├── 020-performance/
+│   ├── 010-introduction.md
+│   └── 020-results.md
+└── 030-conclusion.md
+```
+
+This allows related slides to be grouped in nested directories while retaining an unambiguous presentation order. Markdown files with any unnumbered path component, such as `slides/shared/example.md`, are not treated as slides and can be used for included content.
+
+The `presently:slides:renumber` task only renumbers files directly inside the selected directory. Run it without arguments for the top-level slides, or pass a nested directory explicitly:
+
+``` shell
+$ bake presently:slides:renumber
+$ bake presently:slides:renumber slides_root=slides/020-performance
+```
+
+A slide file contains Markdown with optional frontmatter and presenter notes:
 
 ``` markdown
 ---

--- a/guides/getting-started/readme.md
+++ b/guides/getting-started/readme.md
@@ -32,7 +32,27 @@ $ mkdir slides
 
 ### Writing Slides
 
-Each slide is a Markdown file in the `slides/` directory. Files are ordered alphabetically, so prefix them with numbers:
+Each slide is a Markdown file in the `slides/` directory. Files are ordered by path, and every directory and slide filename must begin with a numeric prefix:
+
+``` text
+slides/
+├── 010-welcome.md
+├── 020-performance/
+│   ├── 010-introduction.md
+│   └── 020-results.md
+└── 030-conclusion.md
+```
+
+This allows related slides to be grouped in nested directories while retaining an unambiguous presentation order. Markdown files with any unnumbered path component, such as `slides/shared/example.md`, are not treated as slides and can be used for included content.
+
+The `presently:slides:renumber` task only renumbers files directly inside the selected directory. Run it without arguments for the top-level slides, or pass a nested directory explicitly:
+
+``` shell
+$ bake presently:slides:renumber
+$ bake presently:slides:renumber slides_root=slides/020-performance
+```
+
+A slide file contains Markdown with optional frontmatter and presenter notes:
 
 ``` markdown
 ---

--- a/lib/presently/application.rb
+++ b/lib/presently/application.rb
@@ -49,7 +49,7 @@ module Presently
 		def controller
 			@controller ||= begin
 				templates = Templates.for(@templates_roots)
-				presentation = Presentation.load(@slides_root, templates: templates)
+				presentation = Presentation.load(@slides_root, templates)
 				
 				PresentationController.new(presentation, state: State.new)
 			end
@@ -81,7 +81,7 @@ module Presently
 			
 			if path == "/export"
 				options = Export.options_from_query(query)
-				presentation = Presentation.load(@slides_root, templates: controller.templates)
+				presentation = Presentation.load(@slides_root, controller.templates)
 				export = Export.new(presentation: presentation, **options)
 				return Protocol::HTTP::Response[200, [["content-type", "text/html"]], [export.call]]
 			end

--- a/lib/presently/export.rb
+++ b/lib/presently/export.rb
@@ -106,7 +106,7 @@ module Presently
 				end
 				
 				builder.tag(:span, class: "export-filename") do
-					builder.tag(:code){builder.text(File.basename(slide.path))}
+					builder.tag(:code){builder.text(slide.relative_path)}
 				end
 				
 				if @timing

--- a/lib/presently/export.rb
+++ b/lib/presently/export.rb
@@ -106,7 +106,7 @@ module Presently
 				end
 				
 				builder.tag(:span, class: "export-filename") do
-					builder.tag(:code){builder.text(slide.relative_path)}
+					builder.tag(:code){builder.text(slide.path)}
 				end
 				
 				if @timing

--- a/lib/presently/presentation.rb
+++ b/lib/presently/presentation.rb
@@ -12,11 +12,18 @@ module Presently
 	# Use {.load} to create a presentation from a directory of Markdown files,
 	# or initialize directly with an array of {Slide} instances.
 	class Presentation
-		# Load and sort slide files from a directory.
-		# @parameter slides_root [String] The directory containing `.md` slide files.
+		# Load and sort numerically-prefixed slide files from a directory tree.
+		# @parameter slides_root [String] The root directory containing `.md` slide files.
 		# @returns [Array(Slide)] The loaded, sorted, non-skipped slides.
 		def self.slides_from(slides_root)
-			Dir.glob(File.join(slides_root, "*.md")).sort.map{|path| Slide.load(path)}.reject(&:skip?)
+			Dir.glob("**/*.md", base: slides_root).sort.filter_map do |relative_path|
+				components = relative_path.split(File::SEPARATOR)
+				next unless components.all?{|component| component.match?(/\A\d/)}
+				
+				path = File.join(slides_root, relative_path)
+				slide = Slide.load(path, relative_path: relative_path)
+				slide unless slide.skip?
+			end
 		end
 		
 		# Load a presentation from a directory of Markdown slide files.

--- a/lib/presently/presentation.rb
+++ b/lib/presently/presentation.rb
@@ -9,46 +9,32 @@ require_relative "templates"
 module Presently
 	# An immutable collection of slides with configuration.
 	#
-	# Use {.load} to create a presentation from a directory of Markdown files,
-	# or initialize directly with an array of {Slide} instances.
+	# Use {.load} to create a presentation from a directory of Markdown files.
+	# Each loaded {Slide} is attached to its presentation and identified by a
+	# path relative to the presentation root.
 	class Presentation
-		# Load and sort numerically-prefixed slide files from a directory tree.
-		# @parameter slides_root [String] The root directory containing `.md` slide files.
-		# @returns [Array(Slide)] The loaded, sorted, non-skipped slides.
-		def self.slides_from(slides_root)
-			Dir.glob("**/*.md", base: slides_root).sort.filter_map do |relative_path|
-				components = relative_path.split(File::SEPARATOR)
-				next unless components.all?{|component| component.match?(/\A\d/)}
-				
-				path = File.join(slides_root, relative_path)
-				slide = Slide.load(path, relative_path: relative_path)
-				slide unless slide.skip?
-			end
-		end
-		
 		# Load a presentation from a directory of Markdown slide files.
-		# @parameter slides_root [String] The directory containing `.md` slide files.
-		# @parameter options [Hash] Additional options passed to {#initialize}.
+		# @parameter root [String] The directory containing `.md` slide files.
+		# @parameter templates [Templates] The template resolver for loading slide templates.
 		# @returns [Presentation] A new presentation with slides loaded from the directory.
-		def self.load(slides_root = "slides", **options)
-			new(slides_from(slides_root), slides_root: slides_root, **options)
+		def self.load(root = "slides", templates = Templates.for)
+			new(root, templates)
 		end
 		
 		# Initialize a new presentation.
-		# @parameter slides [Array(Slide)] The ordered list of slides.
-		# @parameter slides_root [String | Nil] The directory slides were loaded from, used by {#reload}.
+		# @parameter root [String] The root directory containing slide files.
 		# @parameter templates [Templates] The template resolver for loading slide templates.
-		def initialize(slides = [], slides_root: nil, templates: Templates.for)
-			@slides = slides
-			@slides_root = slides_root
+		def initialize(root = "slides", templates = Templates.for)
+			@root = File.expand_path(root)
 			@templates = templates
+			@slides = load_slides
 		end
+		
+		# @attribute [String] The absolute root directory containing slide files.
+		attr :root
 		
 		# @attribute [Array(Slide)] The ordered list of slides.
 		attr :slides
-		
-		# @attribute [String | Nil] The directory slides were loaded from.
-		attr :slides_root
 		
 		# @attribute [Templates] The template resolver.
 		attr :templates
@@ -73,12 +59,23 @@ module Presently
 		end
 		
 		# Return a new {Presentation} with freshly loaded slides and a cleared template cache.
-		# Only works if the presentation was created with {.load}.
-		# @returns [Presentation] A new presentation instance, or `self` if no slides root is set.
+		# @returns [Presentation] A new presentation instance.
 		def reload
-			return self unless @slides_root
-			
-			self.class.new(self.class.slides_from(@slides_root), slides_root: @slides_root, templates: @templates.reload)
+			self.class.new(@root, @templates.reload)
+		end
+		
+		private
+		
+		# Load slides recursively in relative path order.
+		# @returns [Array(Slide)] The loaded, sorted, non-skipped slides.
+		def load_slides
+			Dir.glob("**/*.md", base: @root).sort.filter_map do |path|
+				components = path.split(File::SEPARATOR)
+				next unless components.all?{|component| component.match?(/\A\d/)}
+				
+				slide = Slide.load(self, path)
+				slide unless slide.skip?
+			end
 		end
 	end
 end

--- a/lib/presently/presenter_view.rb
+++ b/lib/presently/presenter_view.rb
@@ -204,7 +204,7 @@ module Presently
 						if slide
 							builder.text(" · ")
 							builder.tag(:code, class: "slide-path") do
-								builder.text(File.basename(slide.path))
+								builder.text(slide.relative_path)
 							end
 							
 							if editor_url = editor_url_for(slide.path)

--- a/lib/presently/presenter_view.rb
+++ b/lib/presently/presenter_view.rb
@@ -204,10 +204,10 @@ module Presently
 						if slide
 							builder.text(" · ")
 							builder.tag(:code, class: "slide-path") do
-								builder.text(slide.relative_path)
+								builder.text(slide.path)
 							end
 							
-							if editor_url = editor_url_for(slide.path)
+							if editor_url = editor_url_for(slide.source_path)
 								builder.tag(:a, href: editor_url, class: "edit-link") do
 									builder.text("✎")
 								end

--- a/lib/presently/slide.rb
+++ b/lib/presently/slide.rb
@@ -62,8 +62,9 @@ module Presently
 			
 			# Parse the file and return a {Slide}.
 			# @parameter path [String] The file path to parse.
+			# @parameter relative_path [String | Nil] The slide path relative to its presentation root.
 			# @returns [Slide]
-			def load(path)
+			def load(path, relative_path: nil)
 				raw = File.read(path)
 				
 				# Parse once, with native front matter support.
@@ -111,7 +112,7 @@ module Presently
 					script = nil
 				end
 				
-				Slide.new(path, front_matter: front_matter, content: content, notes: notes, script: script)
+				Slide.new(path, relative_path: relative_path, front_matter: front_matter, content: content, notes: notes, script: script)
 			end
 			
 			# Expand `![[path/to/file.md]]` include directives in a parsed document.
@@ -184,19 +185,22 @@ module Presently
 		
 		# Load and parse a slide from a Markdown file.
 		# @parameter path [String] The file path to the Markdown slide.
+		# @parameter relative_path [String | Nil] The slide path relative to its presentation root.
 		# @returns [Slide]
-		def self.load(path)
-			Parser.load(path)
+		def self.load(path, relative_path: nil)
+			Parser.load(path, relative_path: relative_path)
 		end
 		
 		# Initialize a slide with pre-parsed data.
 		# @parameter path [String] The file path of the slide.
+		# @parameter relative_path [String | Nil] The slide path relative to its presentation root.
 		# @parameter front_matter [Hash | Nil] The parsed YAML front_matter.
 		# @parameter content [Hash(String, Fragment)] Content sections keyed by heading name.
 		# @parameter notes [Fragment | Nil] The presenter notes as a Markly AST fragment.
 		# @parameter script [String | Nil] JavaScript to execute after the slide renders.
-		def initialize(path, front_matter: nil, content: {}, notes: nil, script: nil)
+		def initialize(path, relative_path: nil, front_matter: nil, content: {}, notes: nil, script: nil)
 			@path = path
+			@relative_path = relative_path || File.basename(path)
 			@front_matter = front_matter
 			@content = content
 			@notes = notes
@@ -205,6 +209,9 @@ module Presently
 		
 		# @attribute [String] The file path of the slide.
 		attr :path
+		
+		# @attribute [String] The slide path relative to its presentation root.
+		attr :relative_path
 		
 		# @attribute [Hash | Nil] The parsed YAML front_matter.
 		attr :front_matter

--- a/lib/presently/slide.rb
+++ b/lib/presently/slide.rb
@@ -61,16 +61,17 @@ module Presently
 			module_function
 			
 			# Parse the file and return a {Slide}.
-			# @parameter path [String] The file path to parse.
-			# @parameter relative_path [String | Nil] The slide path relative to its presentation root.
+			# @parameter presentation [Presentation] The presentation which owns the slide.
+			# @parameter path [String] The slide path relative to the presentation root.
 			# @returns [Slide]
-			def load(path, relative_path: nil)
-				raw = File.read(path)
+			def load(presentation, path)
+				source_path = File.join(presentation.root, path)
+				raw = File.read(source_path)
 				
 				# Parse once, with native front matter support.
 				document = Markly.parse(raw, flags: Markly::UNSAFE | Markly::FRONT_MATTER, extensions: Fragment::EXTENSIONS)
 				
-				expand_includes!(document, File.dirname(path))
+				expand_includes!(document, File.dirname(source_path))
 				
 				# Extract front matter from the first AST node if present.
 				front_matter = nil
@@ -112,7 +113,7 @@ module Presently
 					script = nil
 				end
 				
-				Slide.new(path, relative_path: relative_path, front_matter: front_matter, content: content, notes: notes, script: script)
+				Slide.new(presentation, path, front_matter: front_matter, content: content, notes: notes, script: script)
 			end
 			
 			# Expand `![[path/to/file.md]]` include directives in a parsed document.
@@ -184,34 +185,40 @@ module Presently
 		end
 		
 		# Load and parse a slide from a Markdown file.
-		# @parameter path [String] The file path to the Markdown slide.
-		# @parameter relative_path [String | Nil] The slide path relative to its presentation root.
+		# @parameter presentation [Presentation] The presentation which owns the slide.
+		# @parameter path [String] The slide path relative to the presentation root.
 		# @returns [Slide]
-		def self.load(path, relative_path: nil)
-			Parser.load(path, relative_path: relative_path)
+		def self.load(presentation, path)
+			Parser.load(presentation, path)
 		end
 		
 		# Initialize a slide with pre-parsed data.
-		# @parameter path [String] The file path of the slide.
-		# @parameter relative_path [String | Nil] The slide path relative to its presentation root.
+		# @parameter presentation [Presentation] The presentation which owns the slide.
+		# @parameter path [String] The slide path relative to the presentation root.
 		# @parameter front_matter [Hash | Nil] The parsed YAML front_matter.
 		# @parameter content [Hash(String, Fragment)] Content sections keyed by heading name.
 		# @parameter notes [Fragment | Nil] The presenter notes as a Markly AST fragment.
 		# @parameter script [String | Nil] JavaScript to execute after the slide renders.
-		def initialize(path, relative_path: nil, front_matter: nil, content: {}, notes: nil, script: nil)
+		def initialize(presentation, path, front_matter: nil, content: {}, notes: nil, script: nil)
+			@presentation = presentation
 			@path = path
-			@relative_path = relative_path || File.basename(path)
 			@front_matter = front_matter
 			@content = content
 			@notes = notes
 			@script = script
 		end
 		
-		# @attribute [String] The file path of the slide.
+		# @attribute [Presentation] The presentation which owns the slide.
+		attr :presentation
+		
+		# @attribute [String] The slide path relative to the presentation root.
 		attr :path
 		
-		# @attribute [String] The slide path relative to its presentation root.
-		attr :relative_path
+		# The absolute path of the slide source file.
+		# @returns [String]
+		def source_path
+			File.join(@presentation.root, @path)
+		end
 		
 		# @attribute [Hash | Nil] The parsed YAML front_matter.
 		attr :front_matter

--- a/releases.md
+++ b/releases.md
@@ -1,5 +1,9 @@
 # Releases
 
+## Unreleased
+
+  - Add support for organizing slides in nested directories. Every directory and slide filename must begin with a numeric prefix, and slides are ordered by relative path.
+
 ## v0.15.0
 
 q

--- a/test/presently/presentation.rb
+++ b/test/presently/presentation.rb
@@ -41,12 +41,18 @@ describe Presently::Presentation do
 			let(:presentation) {subject.load(@root)}
 			
 			it "loads recursively in path order" do
-				expect(presentation.slides.map(&:relative_path)).to be == [
+				expect(presentation.slides.map(&:path)).to be == [
 					"010-introduction.md",
 					File.join("020-performance", "010-overview.md"),
 					File.join("020-performance", "030-details", "010-cpu.md"),
 					"030-conclusion.md",
 				]
+			end
+			
+			it "attaches slides to the presentation" do
+				slide = presentation.slides.first
+				expect(slide.presentation).to be_equal(presentation)
+				expect(slide.source_path).to be == File.join(@root, slide.path)
 			end
 			
 			it "requires every path component to have a numeric prefix" do

--- a/test/presently/presentation.rb
+++ b/test/presently/presentation.rb
@@ -4,6 +4,8 @@
 # Copyright, 2026, by Samuel Williams.
 
 require "presently/presentation"
+require "tmpdir"
+require "fileutils"
 
 describe Presently::Presentation do
 	let(:presentation) {subject.load("slides")}
@@ -16,6 +18,41 @@ describe Presently::Presentation do
 		it "sorts slides by filename" do
 			paths = presentation.slides.map(&:path)
 			expect(paths).to be == paths.sort
+		end
+		
+		with "nested directories" do
+			around do |&block|
+				Dir.mktmpdir do |root|
+					@root = root
+					FileUtils.mkdir_p(File.join(root, "020-performance", "030-details"))
+					FileUtils.mkdir_p(File.join(root, "shared"))
+					
+					File.write(File.join(root, "010-introduction.md"), "Introduction\n")
+					File.write(File.join(root, "020-performance", "010-overview.md"), "Overview\n")
+					File.write(File.join(root, "020-performance", "030-details", "010-cpu.md"), "CPU\n")
+					File.write(File.join(root, "020-performance", "notes.md"), "Not a slide\n")
+					File.write(File.join(root, "shared", "010-example.md"), "Not a slide\n")
+					File.write(File.join(root, "030-conclusion.md"), "Conclusion\n")
+					
+					block.call
+				end
+			end
+			
+			let(:presentation) {subject.load(@root)}
+			
+			it "loads recursively in path order" do
+				expect(presentation.slides.map(&:relative_path)).to be == [
+					"010-introduction.md",
+					File.join("020-performance", "010-overview.md"),
+					File.join("020-performance", "030-details", "010-cpu.md"),
+					"030-conclusion.md",
+				]
+			end
+			
+			it "requires every path component to have a numeric prefix" do
+				contents = presentation.slides.map{|slide| slide.content.fetch("body").to_commonmark}
+				expect(contents).not.to have_value(be(:include?, "Not a slide"))
+			end
 		end
 	end
 	

--- a/test/presently/slide.rb
+++ b/test/presently/slide.rb
@@ -3,13 +3,25 @@
 # Released under the MIT License.
 # Copyright, 2026, by Samuel Williams.
 
-require "presently/slide"
+require "presently/presentation"
 require "tmpdir"
 require "fileutils"
 
 describe Presently::Slide do
+	def load_slide(path)
+		presentation = Presently::Presentation.new(File.dirname(path))
+		Presently::Slide.load(presentation, File.basename(path))
+	end
+	
 	let(:slide_path) {File.expand_path("../../slides/010-welcome.md", __dir__)}
-	let(:slide) {subject.load(slide_path)}
+	let(:slide) {load_slide(slide_path)}
+	
+	with "its presentation" do
+		it "retains its relative and source paths" do
+			expect(slide.path).to be == "010-welcome.md"
+			expect(slide.source_path).to be == slide_path
+		end
+	end
 	
 	with "#template" do
 		it "reads template from front_matter" do
@@ -79,7 +91,7 @@ describe Presently::Slide do
 			FileUtils.remove_entry(dir)
 		end
 		
-		let(:slide) {Presently::Slide.load(path)}
+		let(:slide) {load_slide(path)}
 		
 		it "uses default template" do
 			expect(slide.template).to be == "default"
@@ -131,7 +143,7 @@ describe Presently::Slide do
 			FileUtils.remove_entry(dir)
 		end
 		
-		let(:slide) {Presently::Slide.load(path)}
+		let(:slide) {load_slide(path)}
 		
 		it "separates content from notes" do
 			expect(slide.content["body"].to_html).to be(:include?, "Content here")
@@ -151,7 +163,7 @@ describe Presently::Slide do
 			FileUtils.remove_entry(dir)
 		end
 		
-		let(:slide) {Presently::Slide.load(path)}
+		let(:slide) {load_slide(path)}
 		
 		it "extracts the script" do
 			expect(slide.script).to be(:include?, "console.log")
@@ -178,7 +190,7 @@ describe Presently::Slide do
 			FileUtils.remove_entry(dir)
 		end
 		
-		let(:slide) {Presently::Slide.load(path)}
+		let(:slide) {load_slide(path)}
 		
 		it "expands the include into the document" do
 			expect(slide.content).to have_keys("before", "included", "after")
@@ -213,7 +225,7 @@ describe Presently::Slide do
 			FileUtils.remove_entry(dir)
 		end
 		
-		let(:slide) {Presently::Slide.load(path)}
+		let(:slide) {load_slide(path)}
 		
 		it "recursively expands nested includes" do
 			html = slide.content["body"].to_html
@@ -236,7 +248,7 @@ describe Presently::Slide do
 			FileUtils.remove_entry(dir)
 		end
 		
-		let(:slide) {Presently::Slide.load(path)}
+		let(:slide) {load_slide(path)}
 		
 		it "strips front matter from the included file" do
 			html = slide.content["body"].to_html
@@ -257,7 +269,7 @@ describe Presently::Slide do
 			FileUtils.remove_entry(dir)
 		end
 		
-		let(:slide) {Presently::Slide.load(path)}
+		let(:slide) {load_slide(path)}
 		
 		it "reads transition" do
 			expect(slide.transition).to be == "fade"

--- a/test/presently/slide_renderer.rb
+++ b/test/presently/slide_renderer.rb
@@ -3,12 +3,17 @@
 # Released under the MIT License.
 # Copyright, 2026, by Samuel Williams.
 
-require "presently/slide"
+require "presently/presentation"
 require "presently/slide_renderer"
 require "tmpdir"
 require "fileutils"
 
 describe Presently::TemplateScope do
+	def load_slide(path)
+		presentation = Presently::Presentation.new(File.dirname(path))
+		Presently::Slide.load(presentation, File.basename(path))
+	end
+	
 	let(:dir) {Dir.mktmpdir}
 	let(:path) {File.join(dir, "test.md")}
 	
@@ -21,7 +26,7 @@ describe Presently::TemplateScope do
 			File.write(path, "# Title\n\nHello World\n\n# Subtitle\n\nA tagline\n")
 		end
 		
-		let(:slide) {Presently::Slide.load(path)}
+		let(:slide) {load_slide(path)}
 		let(:scope) {Presently::TemplateScope.new(slide)}
 		
 		it "renders a section to HTML" do
@@ -46,7 +51,7 @@ describe Presently::TemplateScope do
 			File.write(path, "Just some content\n")
 		end
 		
-		let(:slide) {Presently::Slide.load(path)}
+		let(:slide) {load_slide(path)}
 		let(:scope) {Presently::TemplateScope.new(slide)}
 		
 		it "returns nil for any section?" do


### PR DESCRIPTION
## Summary

- make each presentation own an absolute slide root and its loaded slides
- identify slides by paths relative to their presentation and derive absolute source paths when needed
- discover slides recursively while requiring every relative path component to start with a numeric prefix
- retain relative paths in presenter, export, and rehearsal tooling
- keep renumbering scoped to the explicitly selected directory and document nested usage
- add coverage for recursive ordering, presentation attachment, and exclusion of unnumbered include directories

## Testing

- `bundle exec sus` against all tracked tests
- `bundle exec rubocop`
- `COVERAGE=PartialSummary bundle exec bake decode:index:coverage lib`