### PR TITLE
Update syntax-js to v0.6.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,6 @@
 	"name": "@socketry/presently",
 	"private": true,
 	"dependencies": {
-		"@socketry/syntax": "socketry/syntax-js"
+		"@socketry/syntax": "^0.6.1"
 	}
 }

--- a/public/_components/@socketry/syntax/Syntax.js
+++ b/public/_components/@socketry/syntax/Syntax.js
@@ -237,12 +237,12 @@ export class Syntax {
 		} catch (error) {
 			throw new LanguageLoadError(name, path, {cause: error});
 		}
-		
+
 		// If the module exports a register function, call it with this instance
 		if (typeof module.default === 'function') {
 			module.default(this);
 		}
-		
+
 		// After calling register, aliases have been registered. Re-resolve the name:
 		let resolvedName = this.#aliases[name] || name;
 		return loader.get(resolvedName);

--- a/public/_components/@socketry/syntax/Syntax/CodeElement.js
+++ b/public/_components/@socketry/syntax/Syntax/CodeElement.js
@@ -1,8 +1,66 @@
 import Syntax from '../Syntax.js';
+import {Match} from './Match.js';
 
 const supportsAdopted =
 	typeof CSSStyleSheet !== 'undefined' &&
 	'adoptedStyleSheets' in Document.prototype;
+
+// These values are defined by the DOM standard. Keep them local so this code
+// does not depend on a global `Node`, which may be unavailable in non-browser
+// DOM implementations.
+const ELEMENT_NODE = 1;
+const TEXT_NODE = 3;
+const CDATA_SECTION_NODE = 4;
+
+/**
+ * Extract the source text and existing markup as source-aligned matches.
+ *
+ * The highlighting pipeline can then insert these matches into the syntax
+ * tree, preserving elements such as links while allowing their contents to
+ * receive syntax highlighting.
+ */
+function extractCode(root) {
+	let text = '';
+	const matches = [];
+
+	function extract(node) {
+		if (node.nodeType === TEXT_NODE || node.nodeType === CDATA_SECTION_NODE) {
+			text += node.nodeValue.replace(/\r/g, '');
+			return;
+		}
+
+		if (node.nodeType !== ELEMENT_NODE) {
+			return;
+		}
+
+		if (node.tagName === 'BR') {
+			text += '\n';
+			return;
+		}
+
+		const offset = text.length;
+		let match = null;
+
+		if (node !== root) {
+			match = new Match(offset, 0, {element: node, force: true, allow: '*'}, '');
+			matches.push(match);
+		}
+
+		for (const child of node.childNodes) {
+			extract(child);
+		}
+
+		if (match) {
+			match.length = text.length - offset;
+			match.endOffset = text.length;
+			match.value = text.slice(offset);
+		}
+	}
+
+	extract(root);
+
+	return {text, matches: matches.filter(match => match.length > 0)};
+}
 
 /**
  * CodeElement - Web Component for syntax highlighting with isolated styles
@@ -18,21 +76,20 @@ export class CodeElement extends HTMLElement {
 
 	#syntax = null;
 	#shadow;
+	#slot = null;
+	#rendered = null;
 	#adoptedHrefs = new Set();
 	#highlighted = false;
-	#readyResolve = null;
 
 	constructor() {
 		super();
-		
+
 		/**
-		 * A promise that resolves when the element has been fully rendered.
-		 * Use this to ensure line measurement APIs return valid results.
+		 * A promise that resolves when the current highlighting attempt completes.
+		 * Check `highlighted` before using line measurement APIs.
 		 * @type {Promise<void>}
 		 */
-		this.ready = new Promise(resolve => {
-			this.#readyResolve = resolve;
-		});
+		this.ready = Promise.resolve();
 	}
 
 	get syntax() {
@@ -43,7 +100,7 @@ export class CodeElement extends HTMLElement {
 		this.#syntax = value;
 		// Re-render with new syntax instance if already connected:
 		if (this.isConnected && !this.#highlighted) {
-			this.#render();
+			this.ready = this.#render();
 		}
 	}
 
@@ -93,29 +150,37 @@ export class CodeElement extends HTMLElement {
 	 */
 	getLineBoundingClientRect(lineNumber) {
 		if (!this.#shadow) return null;
-		
+
 		const code = this.#shadow.querySelector('code');
 		if (!code) return null;
-		
+
 		const lines = code.children;
 		if (lineNumber < 1 || lineNumber > lines.length) return null;
-		
+
 		return lines[lineNumber - 1].getBoundingClientRect();
 	}
-	
+
 	/**
 	 * Get the total number of rendered lines.
 	 * @returns {number} The line count, or 0 if not yet rendered.
 	 */
 	get lineCount() {
 		if (!this.#shadow) return 0;
-		
+
 		const code = this.#shadow.querySelector('code');
 		if (!code) return 0;
-		
+
 		return code.children.length;
 	}
-	
+
+	/**
+	 * Whether the current highlighting attempt has completed successfully.
+	 * @returns {boolean}
+	 */
+	get highlighted() {
+		return this.#highlighted;
+	}
+
 	connectedCallback() {
 		// Detect if we're inside a <pre> element and set wrap attribute
 		if (this.parentElement?.tagName === 'PRE') {
@@ -129,9 +194,11 @@ export class CodeElement extends HTMLElement {
 
 		if (!this.#shadow) {
 			this.#shadow = this.attachShadow({mode: 'open'});
+			this.#slot = document.createElement('slot');
+			this.#shadow.appendChild(this.#slot);
 		}
 
-		this.#render();
+		this.ready = this.#render();
 	}
 
 	attributeChangedCallback(name, oldValue, newValue) {
@@ -144,13 +211,10 @@ export class CodeElement extends HTMLElement {
 			this.isConnected &&
 			this.#shadow
 		) {
-			// Reset highlighted flag and ready promise to allow re-rendering
+			// Reset highlighted state and track the new render attempt:
 			this.#highlighted = false;
-			this.ready = new Promise(resolve => {
-				this.#readyResolve = resolve;
-			});
 			this.#adoptedHrefs.clear();
-			this.#render();
+			this.ready = this.#render();
 		}
 	}
 
@@ -172,16 +236,16 @@ export class CodeElement extends HTMLElement {
 	}
 
 	/**
-	 * Get the code content to highlight
+	 * Get the source text and existing markup to highlight.
 	 */
 	#getCodeContent() {
 		// Check if there's a <code> child element
 		const codeElement = this.querySelector('code');
 		if (codeElement) {
-			return codeElement.textContent;
+			return extractCode(codeElement);
 		}
 
-		return this.textContent;
+		return extractCode(this);
 	}
 
 	/**
@@ -243,6 +307,7 @@ export class CodeElement extends HTMLElement {
 	async #render() {
 		try {
 			const languageName = this.language;
+			const {text: code, matches} = this.#getCodeContent();
 
 			if (!languageName) {
 				console.warn('<syntax-code>: No language specified');
@@ -262,20 +327,31 @@ export class CodeElement extends HTMLElement {
 			// Load theme CSS into shadow root using the language's canonical name
 			await this.#loadStylesheets(language.name);
 
-			const code = this.#getCodeContent();
+			// Highlight off-DOM so the original source remains visible while all
+			// asynchronous work is in progress:
+			const highlighted = await language.process(
+				this.syntax,
+				code,
+				undefined,
+				matches
+			);
 
-			// Clear shadow DOM before rendering (must happen before appendChild to remove old content, but after loadStylesheets since fallback path may have appended <style> elements):
-			this.#shadow.innerHTML = '';
+			// Swap the completed rendering in synchronously. On the first render,
+			// the slot keeps the light-DOM source visible. On subsequent renders,
+			// keep the previous highlighted content visible until its replacement
+			// is ready.
+			if (this.#rendered) {
+				this.#rendered.replaceWith(highlighted);
+			} else if (this.#slot) {
+				this.#slot.replaceWith(highlighted);
+				this.#slot = null;
+			} else {
+				this.#shadow.appendChild(highlighted);
+			}
 
-			// Highlight and append - language.process() returns a <code> element:
-			const highlighted = await language.process(this.syntax, code);
-			this.#shadow.appendChild(highlighted);
-
-			// Clear light DOM only after successful render to avoid losing content on errors:
-			this.textContent = '';
+			this.#rendered = highlighted;
 
 			this.#highlighted = true;
-			this.#readyResolve?.();
 		} catch (error) {
 			console.warn('<syntax-code> render failed:', error);
 		}
@@ -324,8 +400,11 @@ export function upgradeAll(selector, syntax = null) {
 			wrapper.setAttribute('language', language);
 		}
 
-		// Copy the code content into the wrapper
-		wrapper.textContent = element.textContent;
+		// Move the source content into the wrapper so existing markup remains
+		// available for extraction and re-rendering.
+		while (element.firstChild) {
+			wrapper.appendChild(element.firstChild);
+		}
 
 		// Replace <code> with <syntax-code>, leaving <pre> parent in place
 		const parent = element.parentElement;

--- a/public/_components/@socketry/syntax/Syntax/Language.js
+++ b/public/_components/@socketry/syntax/Syntax/Language.js
@@ -239,9 +239,12 @@ export class Language {
 
 	/**
 	 * Build a syntax tree and process it into HTML.
+	 *
+	 * Additional matches can preserve source annotations, such as links, by
+	 * inserting them into the syntax tree before it is reduced to HTML.
 	 */
-	async process(syntax, text, options) {
-		const top = await this.buildTree(syntax, text, 0);
+	async process(syntax, text, options, additionalMatches) {
+		const top = await this.buildTree(syntax, text, 0, additionalMatches);
 
 		const lines = top.splitLines();
 

--- a/public/_components/@socketry/syntax/Syntax/Match.js
+++ b/public/_components/@socketry/syntax/Syntax/Match.js
@@ -108,6 +108,7 @@ export class Match {
 
 		for (const child of this.children) {
 			const end = child.offset;
+			child.parent = this;
 
 			if (child.offset < this.offset) {
 				console.warn(
@@ -284,8 +285,13 @@ export class Match {
 		if (parts[1]) {
 			match.children = [];
 
-			// Update the match's expression based on the current position in the tree:
-			if (this.expression && this.expression.owner) {
+			// Element-backed matches describe authored markup and must retain their
+			// original expression so reduction can recreate that element.
+			if (
+				this.expression &&
+				this.expression.owner &&
+				!match.expression.element
+			) {
 				match.expression =
 					this.expression.owner.getRuleForType(match.expression.type) ||
 					match.expression;

--- a/public/_components/@socketry/syntax/Syntax/Rule.js
+++ b/public/_components/@socketry/syntax/Syntax/Rule.js
@@ -134,14 +134,14 @@ export class Rule {
 	 * Create a conditional matcher that selects a rule based on another capture group.
 	 * Tests a condition capture group against patterns to determine which rule to apply
 	 * to a content capture group.
-	 * 
+	 *
 	 * @param {number} conditionIndex - Capture group index to test against patterns
 	 * @param {number} contentIndex - Capture group index containing content to match
 	 * @param {Array<{pattern?: RegExp, ...rule}>} conditions - Array of condition objects. Each can have:
 	 *   - pattern: RegExp to test against the condition group (optional - if omitted, acts as fallback)
 	 *   - Any rule properties (language, type, etc.) to apply when pattern matches
 	 * @returns {Function} A matches function for use in language rules
-	 * 
+	 *
 	 * @example
 	 * // Script tags with type-based language selection
 	 * language.push({
@@ -152,7 +152,7 @@ export class Rule {
 	 *     {language: 'javascript'} // Fallback for no type or unknown types
 	 *   ])
 	 * });
-	 * 
+	 *
 	 * @example
 	 * // Code fence with language specifier
 	 * language.push({
@@ -163,7 +163,7 @@ export class Rule {
 	 *     {language: 'plaintext'} // Fallback
 	 *   ])
 	 * });
-	 * 
+	 *
 	 * @example
 	 * // Conditional type based on prefix
 	 * language.push({
@@ -201,7 +201,7 @@ export class Rule {
 
 			// Build syntax tree or create match based on rule properties
 			const offset = match.index + match[0].indexOf(content);
-			
+
 			if (ruleProps.language) {
 				return [
 					await Language.buildTree(
@@ -288,6 +288,22 @@ export class Rule {
 	 */
 	static webLinkProcess(baseUrl) {
 		return function (container, match, options) {
+			// Authored links take precedence over generated documentation links.
+			// Depending on the source ranges, the authored link may be either an
+			// ancestor or a descendant of this syntax match.
+			let current = match;
+			while (current) {
+				if (current.expression?.element?.tagName === 'A') {
+					return container;
+				}
+
+				current = current.parent;
+			}
+
+			if (container.matches('a') || container.querySelector('a')) {
+				return container;
+			}
+
 			// Replace the span with an anchor element
 			const anchor = document.createElement('a');
 

--- a/public/_components/@socketry/syntax/package.json
+++ b/public/_components/@socketry/syntax/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@socketry/syntax",
-	"version": "0.3.3",
+	"version": "0.6.1",
 	"description": "A modern, framework-agnostic syntax highlighter using Web Components",
 	"type": "module",
 	"main": "Syntax.js",
@@ -20,8 +20,8 @@
 	],
 	"scripts": {
 		"test": "node --test 'test/**/*.js'",
-		"format": "prettier --write '**/*.{js,json,md}'",
-		"format:check": "prettier --check '**/*.{js,json,md}'"
+		"format": "eslint . --fix",
+		"format:check": "eslint ."
 	},
 	"keywords": [
 		"syntax",
@@ -37,7 +37,8 @@
 		"url": "https://github.com/socketry/syntax-js.git"
 	},
 	"devDependencies": {
-		"jsdom": "^25.0.0",
-		"prettier": "^3.6.2"
+		"@stylistic/eslint-plugin": "^5.10.0",
+		"eslint": "^10.8.1",
+		"jsdom": "^25.0.0"
 	}
 }

--- a/public/_components/@socketry/syntax/readme.md
+++ b/public/_components/@socketry/syntax/readme.md
@@ -2,6 +2,8 @@
 
 A modern, framework-agnostic syntax highlighter using Web Components. This is a reimplementation of [jQuery.Syntax](https://github.com/ioquatix/jquery-syntax) without jQuery dependencies.
 
+[Browse the examples](https://socketry.github.io/syntax-js/examples/).
+
 ## Features
 
 - 🎨 **Modern Web Components** - Uses autonomous custom elements
@@ -128,6 +130,9 @@ const code = document.querySelector('syntax-code');
 // Wait for rendering to complete:
 await code.ready;
 
+// Highlighting may fail while leaving the original source visible:
+if (!code.highlighted) return;
+
 // Get the number of rendered lines:
 console.log(code.lineCount); // 42
 
@@ -136,7 +141,8 @@ const rect = code.getLineBoundingClientRect(5);
 console.log(rect.top, rect.bottom, rect.height);
 ```
 
-- **`ready`** — A `Promise` that resolves when the element has been fully rendered. Await this before calling measurement methods to ensure valid results.
+- **`ready`** — A `Promise` that resolves when the current highlighting attempt completes, whether it succeeds or fails.
+- **`highlighted`** — Returns `true` when the current highlighting attempt has completed successfully. It is `false` while highlighting is pending or after a failure; existing content remains visible in either case.
 - **`lineCount`** — Returns the total number of rendered lines, or `0` if not yet highlighted.
 - **`getLineBoundingClientRect(lineNumber)`** — Returns a `DOMRect` for the given 1-based line number, or `null` if the line doesn't exist. Coordinates are relative to the viewport, just like `Element.getBoundingClientRect()`.
 

--- a/public/_components/@socketry/syntax/themes/base/syntax.css
+++ b/public/_components/@socketry/syntax/themes/base/syntax.css
@@ -3,6 +3,7 @@
 	--syntax-base-hue: 270;
 	--syntax-base-saturation: 60%;
 	--syntax-base-lightness: 50%;
+	--syntax-link-hover-brightness: 1.25;
 }
 
 @media (prefers-color-scheme: dark) {
@@ -27,6 +28,16 @@
 
 code.syntax {
 	tab-size: 2;
+}
+
+code.syntax a {
+	color: inherit;
+	text-decoration: none;
+}
+
+code.syntax a:hover,
+code.syntax a:focus-visible {
+	filter: brightness(var(--syntax-link-hover-brightness));
 }
 
 :host([wrap]) code.syntax .indent {

--- a/public/_components/@socketry/syntax/themes/theming.md
+++ b/public/_components/@socketry/syntax/themes/theming.md
@@ -123,6 +123,17 @@ Override dark mode values for specific themes:
 }
 ```
 
+### Link Interaction
+
+Links preserve the surrounding syntax colors and become brighter when hovered
+or focused. You can adjust the brightness multiplier from the host page:
+
+```css
+syntax-code {
+	--syntax-link-hover-brightness: 1.4;
+}
+```
+
 ## Token Types
 
 All token types automatically get colors derived from the base. You can override individual ones if needed:

--- a/public/application.js
+++ b/public/application.js
@@ -5,8 +5,13 @@ import { applyCodeFocus } from './code-focus.js';
 
 const live = Live.start();
 
-// Highlight code blocks on initial load:
-await Syntax.highlight();
+async function highlightAndApplyCodeFocus() {
+	await Syntax.highlight();
+	await applyCodeFocus();
+}
+
+// Highlight code blocks on initial load and apply focus once rendering finishes:
+await highlightAndApplyCodeFocus();
 
 
 // Run the script for a single slide element.
@@ -53,27 +58,23 @@ live.update = function(id, html, options) {
 		activeTransition.finished.finally(() => {
 			delete document.documentElement.dataset.transition;
 			activeTransition = null;
-			Syntax.highlight();
-			applyCodeFocus();
+			highlightAndApplyCodeFocus();
 		});
 	} else {
 		originalUpdate(id, html, options);
 		runSlideScripts();
-		Syntax.highlight();
-		applyCodeFocus();
+		highlightAndApplyCodeFocus();
 	}
 };
 
 // Re-highlight and apply focus after non-update DOM mutations (e.g. replace):
 const observer = new MutationObserver(() => {
 	if (activeTransition) return;
-	Syntax.highlight();
-	applyCodeFocus();
+	highlightAndApplyCodeFocus();
 });
 observer.observe(document.body, { childList: true, subtree: true });
 
-// Initial focus and script application:
-applyCodeFocus();
+// Initial script application:
 runSlideScripts();
 
 // Jump-to select: forward the selected slide index to the presenter view.

--- a/public/code-focus.js
+++ b/public/code-focus.js
@@ -30,6 +30,7 @@ export async function applyCodeFocus() {
 
 		// Wait for the syntax-code element to finish rendering into its shadow DOM.
 		await code.ready;
+		if (!code.highlighted) continue;
 
 		// Get line positions in screen pixels and convert to CSS pixels using
 		// the scroll container's own rect as the reference frame.


### PR DESCRIPTION
## Summary

- update @socketry/syntax from the repository reference to v0.6.1
- refresh the vendored browser assets
- wait for syntax rendering before measuring and applying code focus
- skip focus measurement when highlighting did not succeed

## Verification

- 118 tracked tests pass
- RuboCop reports no offenses
- JavaScript syntax checks pass
- live Chrome navigation confirms ready settles, highlighted is true, and focus transforms are applied on both code slides