### PR TITLE
Add narrated presentation recording and playback

### DIFF
--- a/bake/presently/export.rb
+++ b/bake/presently/export.rb
@@ -6,6 +6,7 @@
 def initialize(context)
 	super
 	
+	require "base64"
 	require "fileutils"
 	require "uri"
 end
@@ -23,12 +24,7 @@ end
 # @parameter timing [Boolean] Include slide duration and elapsed time. Default: `true`.
 # @parameter timeout [Integer] Seconds to wait for the page to signal readiness. Default: `60`.
 def pdf(output: "presentation.pdf", slides_root: "slides", notes: true, speaker: true, timing: true, slide_width_px: 1920, slide_height_px: 1080, notes_height_px: 300, timeout: 60)
-	require "async"
-	require "async/http/endpoint"
-	require "async/service"
-	require "async/webdriver"
 	require "presently"
-	require "presently/environment/application"
 	
 	page_size = Presently::Export::PageSize.new(
 		slide_width_px:  slide_width_px,
@@ -43,6 +39,121 @@ def pdf(output: "presentation.pdf", slides_root: "slides", notes: true, speaker:
 		slide_width_px: slide_width_px, slide_height_px: slide_height_px, notes_height_px: notes_height_px
 	)
 	
+	with_browser_session(slides_root: slides_root, timeout: timeout) do |session, base_url|
+		session.resize_window(
+			page_size.slide_width_px,
+			page_size.slide_height_px
+		)
+		
+		session.navigate_to("#{base_url}/export?#{query}")
+		
+		# Block until export.js dispatches presently:ready.
+		session.execute_async(<<~JS)
+			const done = arguments[arguments.length - 1];
+			if (window.__PRESENTLY_READY) { done(); return; }
+			document.addEventListener('presently:ready', () => done(), {once: true});
+		JS
+		
+		pdf_data = session.print(
+			background:    true,
+			margin:        {top: 0, bottom: 0, left: 0, right: 0},
+			page:          {width: page_size.slide_width_cm, height: page_height_cm},
+			shrink_to_fit: false
+		)
+		
+		FileUtils.mkdir_p(File.dirname(File.expand_path(output)))
+		File.write(output, pdf_data, mode: "wb")
+	end
+	
+	return {path: output}
+end
+
+# Export the narrated presentation to an MP4 video.
+#
+# This uses Chromium's experimental `Page.startScreenRecording` DevTools
+# command. Until that command reaches Chrome for Testing, pass matching
+# Chromium and ChromeDriver paths explicitly (or through the
+# `PRESENTLY_CHROME_PATH` and `PRESENTLY_CHROMEDRIVER_PATH` environment
+# variables).
+#
+# @parameter output [String] Output MP4 path. Default: `presentation.mp4`.
+# @parameter slides_root [String] The slides directory. Default: `slides`.
+# @parameter width [Integer] Maximum video width. Default: `1920`.
+# @parameter height [Integer] Maximum video height. Default: `1080`.
+# @parameter frame_rate [Integer] Maximum video frame rate. Default: `30`.
+# @parameter timeout [Integer] Seconds to wait for the playback page to load. Default: `60`.
+# @parameter duration_limit [Integer] Maximum presentation duration in seconds. Default: `3600`.
+# @parameter browser_version [String] Chrome for Testing version used when explicit paths are omitted. Default: `canary`.
+# @parameter browser_path [String | Nil] Path to a Chromium executable supporting screen recording.
+# @parameter driver_path [String | Nil] Path to a matching ChromeDriver executable.
+def video(output: "presentation.mp4", slides_root: "slides", width: 1920, height: 1080, frame_rate: 30, timeout: 60, duration_limit: 3600, browser_version: "canary", browser_path: nil, driver_path: nil)
+	browser_path ||= ENV["PRESENTLY_CHROME_PATH"]
+	driver_path ||= ENV["PRESENTLY_CHROMEDRIVER_PATH"]
+	
+	with_browser_session(
+		slides_root: slides_root,
+		timeout: timeout,
+		script_timeout: duration_limit,
+		browser_version: browser_version,
+		browser_path: browser_path,
+		driver_path: driver_path,
+		chrome_arguments: ["--autoplay-policy=no-user-gesture-required", "--hide-scrollbars"]
+	) do |session, base_url|
+		resize_viewport(session, width, height)
+		session.navigate_to("#{base_url}/playback?autoplay=false&controls=false")
+		
+		ready = session.execute_async(<<~JS)
+			const done = arguments[arguments.length - 1];
+			if (window.__PRESENTLY_PLAYBACK_ERROR) { done({error: window.__PRESENTLY_PLAYBACK_ERROR}); return; }
+			if (window.__PRESENTLY_PLAYBACK_READY) { done({ready: true}); return; }
+			document.addEventListener('presently:playback-error', event => done({error: event.detail.message}), {once: true});
+			document.addEventListener('presently:playback-ready', () => done({ready: true}), {once: true});
+		JS
+		
+		raise "Playback preparation failed: #{ready["error"]}" if ready["error"]
+		
+		recording_started = false
+		stream = nil
+		playback = nil
+		
+		begin
+			devtools(session, "Page.startScreenRecording", audio: true, maxWidth: width, maxHeight: height, frameRate: frame_rate)
+			recording_started = true
+			
+			session.execute("window.__PRESENTLY_PLAYBACK_START();")
+			playback = session.execute_async(<<~JS)
+				const done = arguments[arguments.length - 1];
+				if (window.__PRESENTLY_PLAYBACK_ERROR) { done({error: window.__PRESENTLY_PLAYBACK_ERROR}); return; }
+				if (window.__PRESENTLY_PLAYBACK_FINISHED) { done({finished: true}); return; }
+				document.addEventListener('presently:playback-error', event => done({error: event.detail.message}), {once: true});
+				document.addEventListener('presently:playback-finished', () => done({finished: true}), {once: true});
+			JS
+		ensure
+			if recording_started
+				stream = devtools(session, "Page.stopScreenRecording")["stream"]
+			end
+		end
+		
+		raise "Playback failed: #{playback["error"]}" if playback&.dig("error")
+		raise "Chromium did not return the recorded video stream!" unless stream
+		
+		write_devtools_stream(session, stream, output)
+	end
+	
+	return {path: output}
+end
+
+private
+
+def with_browser_session(slides_root:, timeout:, script_timeout: timeout, browser_version: "stable", browser_path: nil, driver_path: nil, chrome_arguments: [])
+	require "async"
+	require "async/http/endpoint"
+	require "async/service"
+	require "async/webdriver"
+	require "presently/environment/application"
+	
+	result = nil
+	
 	Async do |task|
 		# Bind port 0 first so we know the actual address before starting the server.
 		bound_endpoint = Async::HTTP::Endpoint.parse("http://localhost:0").bound
@@ -55,7 +166,7 @@ def pdf(output: "presentation.pdf", slides_root: "slides", notes: true, speaker:
 				endpoint: Async::HTTP::Endpoint.parse("http://localhost", bound_endpoint)
 			)
 			
-			# PDF export always requires an HTTP server, regardless of the configured
+			# Export always requires an HTTP server, regardless of the configured
 			# Lively transport:
 			transport = environment.with(environment.evaluator.http_environment)
 			evaluator = transport.evaluator
@@ -63,53 +174,22 @@ def pdf(output: "presentation.pdf", slides_root: "slides", notes: true, speaker:
 			server_task = task.async{server.run}
 			
 			begin
-				# Derive the actual base URL from the bound socket address.
-				base_url = nil
-				bound_endpoint.local_address_endpoint.each do |endpoint|
-					address = endpoint.address
-					host = address.ipv6? ? "[#{address.ip_address}]" : address.ip_address
-					base_url = "http://#{host}:#{address.ip_port}"
-					break
-				end
-				
-				export_url = "#{base_url}/export?#{query}"
-				
-				bridge = Async::WebDriver::Bridge::Chrome.for(:stable)
+				base_url = export_base_url(bound_endpoint)
+				bridge = chrome_bridge(browser_version, browser_path, driver_path)
 				driver = bridge.start
 				
 				begin
 					client = Async::WebDriver::Client.open(driver.endpoint)
 					
 					begin
-						session = client.session(bridge.default_capabilities)
+						capabilities = bridge.default_capabilities
+						capabilities[:alwaysMatch][:"goog:chromeOptions"][:args].concat(chrome_arguments)
+						session = client.session(capabilities)
 						
 						begin
-							session.resize_window(
-								page_size.slide_width_px,
-								page_size.slide_height_px
-							)
-							
 							session.page_load_timeout = timeout * 1000
-							session.script_timeout = timeout * 1000
-							
-							session.navigate_to(export_url)
-							
-							# Block until export.js dispatches presently:ready.
-							session.execute_async(<<~JS)
-								const done = arguments[arguments.length - 1];
-								if (window.__PRESENTLY_READY) { done(); return; }
-								document.addEventListener('presently:ready', () => done(), {once: true});
-							JS
-							
-							pdf_data = session.print(
-								background:    true,
-								margin:        {top: 0, bottom: 0, left: 0, right: 0},
-								page:          {width: page_size.slide_width_cm, height: page_height_cm},
-								shrink_to_fit: false
-							)
-							
-							FileUtils.mkdir_p(File.dirname(File.expand_path(output)))
-							File.write(output, pdf_data, mode: "wb")
+							session.script_timeout = script_timeout * 1000
+							result = yield(session, base_url)
 						ensure
 							session.close
 						end
@@ -128,5 +208,67 @@ def pdf(output: "presentation.pdf", slides_root: "slides", notes: true, speaker:
 		end
 	end
 	
-	return {path: output}
+	return result
+end
+
+def chrome_bridge(browser_version, browser_path, driver_path)
+	if browser_path || driver_path
+		options = {}
+		options[:browser_path] = File.expand_path(browser_path) if browser_path
+		options[:driver_path] = File.expand_path(driver_path) if driver_path
+		
+		Async::WebDriver::Bridge::Chrome.new(**options)
+	else
+		Async::WebDriver::Bridge::Chrome.for(browser_version.to_sym)
+	end
+end
+
+def export_base_url(bound_endpoint)
+	bound_endpoint.local_address_endpoint.each do |endpoint|
+		address = endpoint.address
+		host = address.ipv6? ? "[#{address.ip_address}]" : address.ip_address
+		return "http://#{host}:#{address.ip_port}"
+	end
+	
+	raise "Could not determine the export server address!"
+end
+
+def resize_viewport(session, width, height)
+	# WebDriver sizes the outer window, while screen recording captures the page
+	# viewport. Measure the browser decoration after an initial resize and
+	# compensate so the recorded video has the requested dimensions.
+	session.resize_window(width, height)
+	dimensions = session.execute(<<~JS)
+		return {outerWidth, outerHeight, innerWidth, innerHeight};
+	JS
+	
+	session.resize_window(
+		width + dimensions["outerWidth"] - dimensions["innerWidth"],
+		height + dimensions["outerHeight"] - dimensions["innerHeight"]
+	)
+end
+
+def devtools(session, command, **parameters)
+	session.post("goog/cdp/execute", {cmd: command, params: parameters})
+rescue Async::WebDriver::Error => error
+	raise "Chromium does not support #{command}: #{error.message}"
+end
+
+def write_devtools_stream(session, stream, output)
+	path = File.expand_path(output)
+	FileUtils.mkdir_p(File.dirname(path))
+	
+	begin
+		File.open(path, "wb") do |file|
+			loop do
+				chunk = devtools(session, "IO.read", handle: stream, size: 1024 * 1024)
+				data = chunk["data"]
+				data = Base64.strict_decode64(data) if chunk["base64Encoded"]
+				file.write(data)
+				break if chunk["eof"]
+			end
+		end
+	ensure
+		devtools(session, "IO.close", handle: stream)
+	end
 end

--- a/bake/presently/recordings.rb
+++ b/bake/presently/recordings.rb
@@ -1,0 +1,72 @@
+# frozen_string_literal: true
+
+# Released under the MIT License.
+# Copyright, 2026, by Samuel Williams.
+
+def initialize(context)
+	super
+	
+	require "pathname"
+	require "presently/recordings/normalizer"
+end
+
+# Normalize all completed slide recordings to a consistent loudness.
+#
+# Original recordings are preserved under `input_root`. Normalized WebM/Opus
+# files are written to the corresponding paths under `output_root`. Existing
+# outputs newer than their source are skipped unless `force` is enabled.
+#
+# @parameter input_root [String] Source recordings directory. Default: `audio`.
+# @parameter output_root [String] Normalized recordings directory. Default: `audio-normalized`.
+# @parameter integrated_loudness [Float] Target integrated loudness in LUFS. Default: `-16.0`.
+# @parameter true_peak [Float] Maximum true peak in dBTP. Default: `-1.5`.
+# @parameter loudness_range [Float] Target loudness range in LU. Default: `11.0`.
+# @parameter bitrate [String] Output Opus bitrate. Default: `128k`.
+# @parameter force [Boolean] Normalize recordings even when output is current. Default: `false`.
+# @parameter command [String] FFmpeg executable. Default: `ffmpeg`.
+def normalize(input_root: "audio", output_root: "audio-normalized", integrated_loudness: -16.0, true_peak: -1.5, loudness_range: 11.0, bitrate: "128k", force: false, command: "ffmpeg")
+	input_root = File.expand_path(input_root)
+	output_root = File.expand_path(output_root)
+	
+	if input_root == output_root
+		raise ArgumentError, "output_root must be different from input_root so originals are preserved!"
+	end
+	
+	files = Dir.glob(File.join(input_root, "**", "*.webm")).sort
+	if files.empty?
+		puts "No WebM recordings found under #{input_root}."
+		return {processed: 0, skipped: 0, output_root: output_root}
+	end
+	
+	normalizer = Presently::Recordings::Normalizer.new(command: command)
+	processed = 0
+	skipped = 0
+	
+	files.each do |input_path|
+		relative_path = Pathname.new(input_path).relative_path_from(Pathname.new(input_root)).to_s
+		output_path = File.join(output_root, relative_path)
+		
+		if !force && File.file?(output_path) && File.mtime(output_path) >= File.mtime(input_path)
+			puts "Skipping #{relative_path} (already normalized)."
+			skipped += 1
+			next
+		end
+		
+		print "Normalizing #{relative_path}... "
+		measurements = normalizer.normalize(
+			input_path,
+			output_path,
+			integrated_loudness: integrated_loudness,
+			true_peak: true_peak,
+			loudness_range: loudness_range,
+			bitrate: bitrate,
+		)
+		input = measurements.fetch(:input)
+		output = measurements.fetch(:output)
+		puts "#{input.fetch("input_i")} LUFS → #{output.fetch("input_i")} LUFS, #{output.fetch("input_tp")} dBTP"
+		processed += 1
+	end
+	
+	puts "Normalized #{processed} recording#{"s" unless processed == 1}; skipped #{skipped}."
+	return {processed: processed, skipped: skipped, output_root: output_root}
+end

--- a/guides/getting-started/readme.md
+++ b/guides/getting-started/readme.md
@@ -91,8 +91,50 @@ Then open two browser windows:
 
 - `http://localhost:9292/` — the audience display.
 - `http://localhost:9292/presenter` — the presenter console.
+- `http://localhost:9292/record` — the slide narration recorder.
+- `http://localhost:9292/playback` — automatic playback with recorded narration.
 
 Advancing slides in either window updates both in real-time via WebSockets.
+
+### Recording Slide Narration
+
+The recording interface is separate from the presenter console because narration is an authoring workflow: each slide can be recorded, reviewed, retaken, and explicitly saved without changing the live presentation controls.
+
+Presently records WebM/Opus audio using the browser microphone, preserving its dynamics for offline normalization. A short delayed audio pipeline excludes approximately 100 milliseconds around the mouse clicks at the beginning and end. Saved recording paths mirror their slide paths under the presentation's `audio/` directory:
+
+``` text
+slides/020-problem/010-overview.md
+audio/020-problem/010-overview.webm
+```
+
+To record narration:
+
+1. Open `http://localhost:9292/record` in a browser with WebM/Opus `MediaRecorder` support.
+2. Select the slide and press **Record**.
+3. Press **Stop**, then review the recording with the audio player.
+4. Press **Save** to replace that slide's existing narration.
+
+Navigating away before saving discards the retake and preserves the previously saved recording.
+
+To normalize completed takes to a consistent `-16 LUFS` target, install FFmpeg and run:
+
+``` shell
+bundle exec bake presently:recordings:normalize
+```
+
+Originals remain under `audio/`; normalized WebM/Opus copies are written under `audio-normalized/` using the same relative paths. The task skips outputs that are newer than their source, so it can be rerun after recording additional slides.
+
+### Playing Recorded Narration
+
+Open `http://localhost:9292/playback` after every slide has a recording. Press **Start presentation** and Presently will play each narration track, run the slide's script, preserve its transition, and advance when the narration ends. Normalized recordings are preferred, with the corresponding original recording used as a fallback.
+
+For browser automation or video capture, open:
+
+``` text
+http://localhost:9292/playback?autoplay=true&controls=false
+```
+
+The playback page sets `window.__PRESENTLY_PLAYBACK_READY` after its slides, fonts, syntax highlighting, and audio metadata are loaded. It sets `window.__PRESENTLY_PLAYBACK_FINISHED` when the final narration ends. It also dispatches `presently:playback-ready` and `presently:playback-finished` events for event-driven integrations.
 
 ### Keyboard Controls
 

--- a/guides/getting-started/readme.md
+++ b/guides/getting-started/readme.md
@@ -136,6 +136,16 @@ http://localhost:9292/playback?autoplay=true&controls=false
 
 The playback page sets `window.__PRESENTLY_PLAYBACK_READY` after its slides, fonts, syntax highlighting, and audio metadata are loaded. It sets `window.__PRESENTLY_PLAYBACK_FINISHED` when the final narration ends. It also dispatches `presently:playback-ready` and `presently:playback-finished` events for event-driven integrations.
 
+To export the narrated presentation directly to MP4, use a Chromium and matching ChromeDriver build that supports the experimental `Page.startScreenRecording` DevTools command:
+
+``` shell
+PRESENTLY_CHROME_PATH=/path/to/chromium \
+PRESENTLY_CHROMEDRIVER_PATH=/path/to/chromedriver \
+bundle exec bake presently:export:video output=presentation.mp4
+```
+
+The defaults are 1920×1080 at up to 30 frames per second. The exporter starts an isolated Presently server, waits for playback to become ready, records until the final narration ends, and writes Chromium's MP4 stream to the selected output path.
+
 ### Keyboard Controls
 
 - **Arrow Right / Space / Page Down** — next slide.

--- a/lib/presently.rb
+++ b/lib/presently.rb
@@ -5,5 +5,9 @@
 
 require_relative "presently/version"
 
+require_relative "presently/recordings"
+require_relative "presently/recordings/normalizer"
+require_relative "presently/recording_view"
+require_relative "presently/playback"
 require_relative "presently/application"
 require_relative "presently/environment/application"

--- a/lib/presently/application.rb
+++ b/lib/presently/application.rb
@@ -10,6 +10,9 @@ require_relative "presentation"
 require_relative "presentation_controller"
 require_relative "display_view"
 require_relative "presenter_view"
+require_relative "recording_view"
+require_relative "recordings"
+require_relative "playback"
 require_relative "export"
 require_relative "page"
 require_relative "state"
@@ -25,9 +28,13 @@ module Presently
 		# @parameter delegate [Protocol::HTTP::Middleware] The next middleware in the chain.
 		# @parameter slides_root [String] The directory containing slide files.
 		# @parameter templates_roots [Array(String)] Additional directories to search for templates.
-		def initialize(delegate, slides_root: "slides", templates_roots: [])
+		# @parameter recordings_root [String | Nil] Directory where source narration is stored. Defaults to `audio` beside the slides directory.
+		# @parameter playback_recordings_root [String | Nil] Directory containing normalized narration. Defaults to `audio-normalized` beside the slides directory.
+		def initialize(delegate, slides_root: "slides", templates_roots: [], recordings_root: nil, playback_recordings_root: nil)
 			@slides_root = slides_root
 			@templates_roots = templates_roots
+			@recordings = Recordings.new(recordings_root || File.expand_path("../audio", slides_root))
+			@playback_recordings = Recordings.new(playback_recordings_root || File.expand_path("../audio-normalized", slides_root))
 			
 			super(delegate)
 		end
@@ -35,7 +42,7 @@ module Presently
 		# The view classes that this application allows.
 		# @returns [Array(Class)] The allowed view classes.
 		def allowed_views
-			[DisplayView, PresenterView]
+			[DisplayView, PresenterView, RecordingView]
 		end
 		
 		# The shared state passed to all views via the resolver.
@@ -70,6 +77,8 @@ module Presently
 				DisplayView.new(controller: controller)
 			when "/presenter"
 				PresenterView.new(controller: controller)
+			when "/record"
+				RecordingView.new(controller: controller)
 			end
 		end
 		
@@ -78,6 +87,26 @@ module Presently
 		# @returns [Protocol::HTTP::Response] The HTTP response.
 		def handle(request)
 			path, query = request.path.split("?", 2)
+			
+			if path == "/recordings"
+				return handle_recording(request, query)
+			end
+			
+			if path == "/playback/recordings"
+				return handle_playback_recording(request, query)
+			end
+			
+			if path == "/playback"
+				presentation = Presentation.load(@slides_root, controller.templates)
+				recording_urls = presentation.slides.each_index.map do |index|
+					slide = presentation.slides[index]
+					if @playback_recordings.exist?(slide) || @recordings.exist?(slide)
+						"/playback/recordings?index=#{index}"
+					end
+				end
+				playback = Playback.new(presentation: presentation, recording_urls: recording_urls, **Playback.options_from_query(query))
+				return Protocol::HTTP::Response[200, [["content-type", "text/html"]], [playback.call]]
+			end
 			
 			if path == "/export"
 				options = Export.options_from_query(query)
@@ -92,6 +121,93 @@ module Presently
 			else
 				return Protocol::HTTP::Response[404, [], ["Not Found"]]
 			end
+		end
+		
+		private
+		
+		# Handle reading and writing a slide recording.
+		# @parameter request [Protocol::HTTP::Request] The incoming request.
+		# @parameter query [String | Nil] The raw query string.
+		# @returns [Protocol::HTTP::Response]
+		def handle_recording(request, query)
+			index = recording_index(query)
+			return Protocol::HTTP::Response[400, [], ["A valid slide index is required."]] unless index
+			
+			slide = controller.slides[index]
+			return Protocol::HTTP::Response[404, [], ["Slide not found."]] unless slide
+			
+			case request.method
+			when "GET", "HEAD"
+				serve_recording(request, slide, @recordings)
+			when "PUT"
+				store_recording(request, slide)
+			else
+				Protocol::HTTP::Response[405, [["allow", "GET, HEAD, PUT"]], ["Method not allowed."]]
+			end
+		end
+		
+		# Serve normalized narration for playback, falling back to the source take.
+		def handle_playback_recording(request, query)
+			unless request.method == "GET" || request.method == "HEAD"
+				return Protocol::HTTP::Response[405, [["allow", "GET, HEAD"]], ["Method not allowed."]]
+			end
+			
+			index = recording_index(query)
+			return Protocol::HTTP::Response[400, [], ["A valid slide index is required."]] unless index
+			
+			slide = controller.slides[index]
+			return Protocol::HTTP::Response[404, [], ["Slide not found."]] unless slide
+			
+			recordings = @playback_recordings.exist?(slide) ? @playback_recordings : @recordings
+			serve_recording(request, slide, recordings)
+		end
+		
+		# Parse the slide index from a recording query string.
+		# @parameter query [String | Nil] The raw query string.
+		# @returns [Integer | Nil]
+		def recording_index(query)
+			parameters = URI.decode_www_form(query.to_s).to_h
+			Integer(parameters.fetch("index"))
+		rescue ArgumentError, KeyError
+			nil
+		end
+		
+		# Serve an existing recording.
+		# @parameter request [Protocol::HTTP::Request] The incoming request.
+		# @parameter slide [Slide] The requested slide.
+		# @returns [Protocol::HTTP::Response]
+		def serve_recording(request, slide, recordings)
+			unless recordings.exist?(slide)
+				return Protocol::HTTP::Response[404, [], ["Recording not found."]]
+			end
+			
+			headers = [
+				["content-type", Recordings::CONTENT_TYPE],
+				["cache-control", "no-store"],
+			]
+			body = recordings.read(slide) unless request.method == "HEAD"
+			
+			Protocol::HTTP::Response[200, headers, body]
+		end
+		
+		# Store an uploaded recording.
+		# @parameter request [Protocol::HTTP::Request] The incoming request.
+		# @parameter slide [Slide] The slide being recorded.
+		# @returns [Protocol::HTTP::Response]
+		def store_recording(request, slide)
+			content_type = request.headers["content-type"]&.split(";", 2)&.first
+			unless content_type == Recordings::CONTENT_TYPE
+				return Protocol::HTTP::Response[415, [], ["Expected #{Recordings::CONTENT_TYPE}."]]
+			end
+			
+			unless request.body
+				return Protocol::HTTP::Response[400, [], ["A recording body is required."]]
+			end
+			
+			@recordings.write(slide, request.body)
+			Protocol::HTTP::Response[201, [["content-type", "application/json"]], ["{\"saved\":true}"]]
+		rescue Recordings::TooLarge => error
+			Protocol::HTTP::Response[413, [], [error.message]]
 		end
 	end
 end

--- a/lib/presently/environment/application.rb
+++ b/lib/presently/environment/application.rb
@@ -30,6 +30,18 @@ module Presently
 				[File.expand_path("templates", self.root)].select{|d| File.directory?(d)}
 			end
 			
+			# The root directory where per-slide narration recordings are stored.
+			# @returns [String] Absolute path to the recording root.
+			def recordings_root
+				File.expand_path("audio", self.root)
+			end
+			
+			# The root directory containing normalized narration used for playback.
+			# @returns [String] Absolute path to the playback recording root.
+			def playback_recordings_root
+				File.expand_path("audio-normalized", self.root)
+			end
+			
 			# The application class to use.
 			# @returns [Class] The Presently application class.
 			def application
@@ -42,6 +54,8 @@ module Presently
 				application = self.application
 				slides_root = self.slides_root
 				templates_roots = self.templates_roots
+				recordings_root = self.recordings_root
+				playback_recordings_root = self.playback_recordings_root
 				root = self.root
 				
 				::Protocol::HTTP::Middleware.build do |builder|
@@ -56,7 +70,9 @@ module Presently
 					
 					builder.use application,
 						slides_root: slides_root,
-						templates_roots: templates_roots
+						templates_roots: templates_roots,
+						recordings_root: recordings_root,
+						playback_recordings_root: playback_recordings_root
 				end
 			end
 		end

--- a/lib/presently/playback.rb
+++ b/lib/presently/playback.rb
@@ -1,0 +1,69 @@
+# frozen_string_literal: true
+
+# Released under the MIT License.
+# Copyright, 2026, by Samuel Williams.
+
+require "uri"
+require "xrb/template"
+
+require_relative "slide_renderer"
+
+module Presently
+	# Renders an isolated, narrated presentation for review and video capture.
+	#
+	# Unlike the live display, playback owns its current slide entirely in the
+	# browser and does not update the shared presentation controller.
+	class Playback
+		TEMPLATE = XRB::Template.load_file(File.expand_path("playback.xrb", __dir__))
+		
+		# Parse playback options from a URL query string.
+		# @parameter query [String | Nil] The raw query string.
+		# @returns [Hash] Options suitable for passing to {.new}.
+		def self.options_from_query(query)
+			parameters = URI.decode_www_form(query.to_s).to_h
+			
+			{
+				autoplay: parameters["autoplay"] == "true",
+				controls: parameters["controls"] != "false",
+			}
+		end
+		
+		# @parameter presentation [Presentation] The presentation to play.
+		# @parameter recording_urls [Array(String | Nil)] Narration URL for each slide.
+		# @parameter autoplay [Boolean] Whether playback should begin when ready.
+		# @parameter controls [Boolean] Whether playback controls should be visible.
+		def initialize(presentation:, recording_urls:, autoplay: false, controls: true)
+			@presentation = presentation
+			@recording_urls = recording_urls
+			@autoplay = autoplay
+			@controls = controls
+			@renderer = SlideRenderer.new(templates: presentation.templates)
+		end
+		
+		attr :autoplay
+		attr :controls
+		
+		# @returns [Array(Slide)] The slides in playback order.
+		def slides
+			@presentation.slides
+		end
+		
+		# @returns [String | Nil] The narration URL for a slide index.
+		def recording_url(index)
+			@recording_urls[index]
+		end
+		
+		# Render one slide as HTML.
+		# @parameter slide [Slide] The slide to render.
+		# @returns [XRB::MarkupString]
+		def render_slide(slide)
+			@renderer.render_to_html(slide)
+		end
+		
+		# Render the complete playback page.
+		# @returns [String]
+		def call
+			TEMPLATE.to_string(self)
+		end
+	end
+end

--- a/lib/presently/playback.xrb
+++ b/lib/presently/playback.xrb
@@ -1,0 +1,55 @@
+<!DOCTYPE html>
+<html>
+	<head>
+		<title>Presently Playback</title>
+		
+		<meta charset="UTF-8" />
+		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		
+		<link rel="icon" type="image/png" href="/_static/icon.png" />
+		<link rel="stylesheet" href="/_static/site.css" type="text/css" media="screen" />
+		<link rel="stylesheet" href="/_static/index.css" type="text/css" media="screen" />
+		<link rel="stylesheet" href="/_static/custom.css" type="text/css" media="screen" />
+		<link rel="stylesheet" href="/_components/@socketry/syntax/themes/base/syntax.css" type="text/css" media="screen" />
+		
+		<script type="importmap">
+		{
+			"imports": {
+				"@socketry/syntax": "/_components/@socketry/syntax/Syntax.js"
+			}
+		}
+		</script>
+		
+		<script type="module" src="/playback.js"></script>
+	</head>
+	
+	<body class="playback" data-autoplay="#{self.autoplay}" data-controls="#{self.controls}">
+		<main class="playback-stage">
+			<?r self.slides.each_with_index do |slide, index| ?>
+			<div class="playback-frame" data-index="#{index}" data-transition="#{slide.transition}" data-duration="#{slide.duration}"<?r if index != 0 ?> hidden<?r end ?>>
+				#{self.render_slide(slide)}
+			</div>
+			<?r end ?>
+		</main>
+		
+		<div class="playback-audio" hidden>
+			<?r self.slides.each_with_index do |slide, index| ?>
+				<?r if recording_url = self.recording_url(index) ?>
+				<audio data-index="#{index}" preload="auto" src="#{recording_url}"></audio>
+				<?r end ?>
+			<?r end ?>
+		</div>
+		
+		<div class="playback-start-screen">
+			<button class="playback-start" type="button" disabled>▶ Start presentation</button>
+			<p class="playback-status">Preparing presentation…</p>
+		</div>
+		
+		<nav class="playback-controls" aria-label="Playback controls">
+			<button class="playback-previous" type="button" title="Previous slide">◀</button>
+			<button class="playback-toggle" type="button" title="Play or pause">▶</button>
+			<button class="playback-next" type="button" title="Next slide">▶|</button>
+			<span class="playback-counter">1 / #{self.slides.length}</span>
+		</nav>
+	</body>
+</html>

--- a/lib/presently/recording_view.rb
+++ b/lib/presently/recording_view.rb
@@ -1,0 +1,160 @@
+# frozen_string_literal: true
+
+# Released under the MIT License.
+# Copyright, 2026, by Samuel Williams.
+
+require "live"
+
+require_relative "editor"
+require_relative "slide_renderer"
+
+module Presently
+	# A dedicated interface for recording one narration track per slide.
+	#
+	# Recording is intentionally separate from {PresenterView}: presenting is a
+	# live performance interface, while recording is an authoring workflow with
+	# retakes, playback, and explicit saving.
+	class RecordingView < Live::View
+		# Initialize a recording view.
+		# @parameter id [String] The unique element identifier.
+		# @parameter data [Hash] The element data attributes.
+		# @parameter controller [PresentationController | Nil] The shared presentation controller.
+		def initialize(id = Live::Element.unique_id, data = {}, controller: nil)
+			super(id, data)
+			@controller = controller
+			@slide_renderer = SlideRenderer.new(css_class: "slide recording-slide", templates: controller&.templates)
+		end
+		
+		# Bind this view to a page and register for slide changes.
+		# @parameter page [Live::Page] The page this view is bound to.
+		def bind(page)
+			super
+			@controller.add_listener(self)
+		end
+		
+		# Close this view and unregister it from the controller.
+		def close
+			@controller.remove_listener(self)
+			super
+		end
+		
+		# Update the recording interface when the current slide changes.
+		def slide_changed!
+			self.update!
+		end
+		
+		# Handle navigation events from the recording interface.
+		# @parameter event [Hash] The forwarded browser event.
+		def handle(event)
+			case event.dig(:detail, :action)
+			when "next"
+				@controller.advance!
+			when "previous"
+				@controller.retreat!
+			when "reload"
+				@controller.reload!
+			when "jump"
+				if index = event.dig(:detail, :index)
+					@controller.go_to(index.to_i)
+				end
+			end
+		end
+		
+		# Generate an editor URL for the given file path.
+		# @parameter path [String] The file path.
+		# @parameter line [Integer] The line number.
+		# @returns [String | Nil]
+		def editor_url_for(path, line = 1)
+			Editor.url_for(path, line)
+		end
+		
+		# Render the recording interface.
+		# @parameter builder [XRB::Builder] The HTML builder.
+		def render(builder)
+			slide = @controller.current_slide
+			return unless slide
+			
+			index = @controller.current_index
+			recording_url = "/recordings?index=#{index}"
+			
+			builder.tag(:div, class: "recorder") do
+				render_navigation(builder, slide)
+				
+				builder.tag(:div, class: "recording-workspace") do
+					builder.tag(:div, class: "recording-preview") do
+						@slide_renderer.render(builder, slide)
+					end
+					
+					builder.tag(:aside, class: "recording-sidebar") do
+						builder.tag(:section, class: "recording-panel") do
+							builder.tag(:h2){builder.text("Narration")}
+							builder.tag(:p){builder.text("Record, review, and save one audio track for this slide.")}
+							
+							builder.tag("presently-recorder",
+								id: "presently-recorder-#{index}",
+								"data-recording-url": recording_url
+							) do
+								builder.tag(:div, class: "recording-actions") do
+									builder.tag(:button, class: "recording-start", type: "button"){builder.text("● Record")}
+									builder.tag(:button, class: "recording-stop", type: "button", disabled: true){builder.text("■ Stop")}
+									builder.tag(:button, class: "recording-save", type: "button", disabled: true){builder.text("Save")}
+									builder.tag(:span, class: "recording-indicator", "aria-hidden": "true"){}
+									builder.tag(:span, class: "recording-time"){builder.text("0:00")}
+								end
+								
+								builder.tag(:audio, class: "recording-playback", controls: true, preload: "metadata", hidden: true){}
+								builder.tag(:p, class: "recording-status", role: "status"){builder.text("Checking for an existing recording…")}
+							end
+						end
+						
+						builder.tag(:section, class: "recording-notes") do
+							builder.tag(:h2){builder.text("Notes")}
+							if notes = slide.notes
+								builder.raw(notes.to_html)
+							else
+								builder.tag(:p, class: "no-notes"){builder.text("No presenter notes for this slide.")}
+							end
+						end
+					end
+				end
+			end
+		end
+		
+		private
+		
+		# Render navigation controls for the recording interface.
+		# @parameter builder [XRB::Builder] The HTML builder.
+		# @parameter slide [Slide] The current slide.
+		def render_navigation(builder, slide)
+			builder.tag(:div, class: "controls recording-navigation") do
+				builder.tag(:button, onClick: forward_event(action: "previous")){builder.text("← Previous")}
+				
+				builder.tag(:span, class: "slide-info") do
+					builder.text("Slide #{@controller.current_index + 1} of #{@controller.slide_count} · ")
+					builder.tag(:code, class: "slide-path"){builder.text(slide.path)}
+					
+					if editor_url = editor_url_for(slide.source_path)
+						builder.tag(:a, href: editor_url, class: "edit-link"){builder.text("✎")}
+					end
+				end
+				
+				builder.tag(:button, onClick: forward_event(action: "next")){builder.text("Next →")}
+				
+				markers = @controller.slides.each_with_index.filter_map do |candidate, index|
+					[index, candidate.marker] if candidate.marker
+				end
+				
+				unless markers.empty?
+					builder.tag(:select, class: "jump-to", "data-live-id": @id) do
+						builder.tag(:option, value: "", disabled: true, selected: true){builder.text("Jump to…")}
+						markers.each do |index, label|
+							builder.tag(:option, value: index){builder.text(label)}
+						end
+					end
+				end
+				
+				builder.tag(:button, onClick: forward_event(action: "reload"), class: "reload"){builder.text("↻ Reload")}
+			end
+		end
+	end
+end

--- a/lib/presently/recordings.rb
+++ b/lib/presently/recordings.rb
@@ -1,0 +1,100 @@
+# frozen_string_literal: true
+
+# Released under the MIT License.
+# Copyright, 2026, by Samuel Williams.
+
+require "fileutils"
+require "tempfile"
+
+require "protocol/http/body/file"
+
+module Presently
+	# Stores one WebM narration recording for each slide.
+	#
+	# Recording paths mirror slide paths. For example,
+	# `slides/020-topic/010-example.md` is stored as
+	# `audio/020-topic/010-example.webm`.
+	class Recordings
+		# The media type produced by the browser recorder.
+		CONTENT_TYPE = "audio/webm"
+		
+		# The maximum accepted recording size (128 MiB).
+		MAXIMUM_SIZE = 128 * 1024 * 1024
+		
+		# Raised when an uploaded recording exceeds {MAXIMUM_SIZE}.
+		class TooLarge < StandardError
+		end
+		
+		# Initialize the recording store.
+		# @parameter root [String] The directory where recordings are stored.
+		# @parameter maximum_size [Integer] Maximum accepted recording size in bytes.
+		def initialize(root, maximum_size: MAXIMUM_SIZE)
+			@root = File.expand_path(root)
+			@maximum_size = maximum_size
+		end
+		
+		# @attribute [String] The absolute recording root.
+		attr :root
+		
+		# The recording path relative to {#root} for the given slide.
+		# @parameter slide [Slide] The slide whose recording path is required.
+		# @returns [String]
+		def relative_path(slide)
+			slide.path.sub(/\.md\z/, ".webm")
+		end
+		
+		# The absolute recording path for the given slide.
+		# @parameter slide [Slide] The slide whose recording path is required.
+		# @returns [String]
+		def path(slide)
+			File.join(@root, relative_path(slide))
+		end
+		
+		# Whether the slide has a recording.
+		# @parameter slide [Slide] The slide to check.
+		# @returns [Boolean]
+		def exist?(slide)
+			File.file?(path(slide))
+		end
+		
+		# Open the recording as an HTTP body.
+		# @parameter slide [Slide] The slide to read.
+		# @returns [Protocol::HTTP::Body::File | Nil]
+		def read(slide)
+			if exist?(slide)
+				Protocol::HTTP::Body::File.open(path(slide))
+			end
+		end
+		
+		# Write a recording atomically.
+		#
+		# The request body is copied to a temporary file in the destination
+		# directory, then renamed over the existing recording only after the
+		# upload completes successfully.
+		# @parameter slide [Slide] The slide being recorded.
+		# @parameter body [Protocol::HTTP::Body::Readable] The uploaded recording.
+		# @returns [String] The absolute destination path.
+		# @raises [TooLarge] If the recording exceeds {MAXIMUM_SIZE}.
+		def write(slide, body)
+			destination = path(slide)
+			directory = File.dirname(destination)
+			FileUtils.mkdir_p(directory)
+			
+			Tempfile.create(["presently-recording", ".webm"], directory, binmode: true) do |file|
+				size = 0
+				
+				while chunk = body.read
+					size += chunk.bytesize
+					raise TooLarge, "Recording exceeds #{@maximum_size} bytes!" if size > @maximum_size
+					
+					file.write(chunk)
+				end
+				
+				file.flush
+				File.rename(file.path, destination)
+			end
+			
+			return destination
+		end
+	end
+end

--- a/lib/presently/recordings/normalizer.rb
+++ b/lib/presently/recordings/normalizer.rb
@@ -1,0 +1,183 @@
+# frozen_string_literal: true
+
+# Released under the MIT License.
+# Copyright, 2026, by Samuel Williams.
+
+require "fileutils"
+require "json"
+require "open3"
+require "tempfile"
+
+module Presently
+	class Recordings
+		# Normalizes recording loudness using measured gain and peak limiting.
+		#
+		# Short spoken recordings can have isolated peaks which prevent FFmpeg's
+		# two-pass `loudnorm` filter from reaching its integrated loudness target.
+		# This implementation measures the result of a gain and limiter filter,
+		# adjusting the gain until the complete recording reaches the target. The
+		# limiter retains headroom for peaks introduced by Opus encoding.
+		class Normalizer
+			# The default integrated loudness target for spoken web content.
+			INTEGRATED_LOUDNESS = -16.0
+			
+			# The default maximum true peak, in dBTP.
+			TRUE_PEAK = -1.5
+			
+			# The default loudness range target.
+			LOUDNESS_RANGE = 11.0
+			
+			# The default Opus bitrate used for normalized recordings.
+			BITRATE = "128k"
+			
+			# Additional headroom retained before lossy encoding, in dB.
+			ENCODER_HEADROOM = 0.75
+			
+			# Maximum acceptable difference from the integrated loudness target.
+			LOUDNESS_TOLERANCE = 0.05
+			
+			# Maximum gain refinements performed before encoding.
+			MAXIMUM_ITERATIONS = 12
+			
+			# Maximum encodings performed while accounting for codec peak overshoot.
+			MAXIMUM_ENCODINGS = 4
+			
+			# Additional headroom added when an encoded file exceeds the peak target.
+			PEAK_CORRECTION_MARGIN = 0.1
+			
+			# Raised when FFmpeg cannot analyze or normalize a recording.
+			class Error < StandardError
+			end
+			
+			# Initialize the normalizer.
+			# @parameter command [String] The FFmpeg executable.
+			def initialize(command: "ffmpeg")
+				@command = command
+			end
+			
+			# Normalize one recording to a separate output path.
+			# @parameter input_path [String] Source WebM recording.
+			# @parameter output_path [String] Destination WebM recording.
+			# @parameter integrated_loudness [Numeric] Target integrated loudness in LUFS.
+			# @parameter true_peak [Numeric] Maximum true peak in dBTP.
+			# @parameter loudness_range [Numeric] Target loudness range in LU.
+			# @parameter bitrate [String] Output Opus bitrate.
+			# @returns [Hash] Input and normalized loudness measurements.
+			def normalize(input_path, output_path, integrated_loudness: INTEGRATED_LOUDNESS, true_peak: TRUE_PEAK, loudness_range: LOUDNESS_RANGE, bitrate: BITRATE)
+				input_path = File.expand_path(input_path)
+				output_path = File.expand_path(output_path)
+				input_measurements = measure(input_path, integrated_loudness, true_peak, loudness_range)
+				limiter_peak = true_peak - ENCODER_HEADROOM
+				
+				FileUtils.mkdir_p(File.dirname(output_path))
+				
+				Tempfile.create(["presently-normalized", ".webm"], File.dirname(output_path), binmode: true) do |temporary|
+					temporary.close
+					
+					MAXIMUM_ENCODINGS.times do
+						filter, gain = normalization_filter(input_path, integrated_loudness, limiter_peak, loudness_range, input_measurements)
+						
+						run(
+							"-i", input_path,
+							"-map", "0:a:0",
+							"-af", filter,
+							"-c:a", "libopus",
+							"-b:a", bitrate,
+							"-vbr", "on",
+							"-vn",
+							"-f", "webm",
+							"-y", temporary.path,
+						)
+						
+						output_measurements = measure(temporary.path, integrated_loudness, true_peak, loudness_range)
+						output_peak = Float(output_measurements.fetch("input_tp"))
+						
+						if output_peak <= true_peak
+							File.rename(temporary.path, output_path)
+							
+							return {
+								input: input_measurements,
+								output: output_measurements,
+								gain: gain,
+							}
+						end
+						
+						limiter_peak -= output_peak - true_peak + PEAK_CORRECTION_MARGIN
+					end
+					
+					raise Error, "Could not constrain the encoded true peak to #{true_peak} dBTP for #{input_path}!"
+				end
+			end
+			
+			private
+			
+			def measure(input_path, integrated_loudness, true_peak, loudness_range, before: nil)
+				filter = [
+					before,
+					"loudnorm=I=#{integrated_loudness}:TP=#{true_peak}:LRA=#{loudness_range}:print_format=json",
+				].compact.join(",")
+				output = run(
+					"-i", input_path,
+					"-map", "0:a:0",
+					"-af", filter,
+					"-f", "null",
+					"-",
+				)
+				
+				json = output.match(/\{\s*"input_i".*?\}/m)&.[](0)
+				raise Error, "FFmpeg did not report loudness measurements for #{input_path}!" unless json
+				
+				measurements = JSON.parse(json)
+				%w[input_i input_tp input_lra input_thresh target_offset].each do |key|
+					Float(measurements.fetch(key))
+				rescue ArgumentError, KeyError
+					raise Error, "FFmpeg reported an invalid #{key} measurement for #{input_path}!"
+				end
+				
+				return measurements
+			end
+			
+			def normalization_filter(input_path, integrated_loudness, limiter_peak, loudness_range, input_measurements)
+				gain = integrated_loudness - Float(input_measurements.fetch("input_i"))
+				limiter = 10.0 ** (limiter_peak / 20.0)
+				
+				MAXIMUM_ITERATIONS.times do
+					filter = gain_and_limiter_filter(gain, limiter)
+					measurements = measure(input_path, integrated_loudness, limiter_peak, loudness_range, before: filter)
+					correction = integrated_loudness - Float(measurements.fetch("input_i"))
+					
+					return [filter, gain] if correction.abs <= LOUDNESS_TOLERANCE
+					
+					gain += correction
+				end
+				
+				raise Error, "Could not converge on #{integrated_loudness} LUFS for #{input_path}!"
+			end
+			
+			def gain_and_limiter_filter(gain, limiter)
+				gain = format("%.4f", gain)
+				limiter = format("%.8f", limiter)
+				
+				return "volume=#{gain}dB,alimiter=limit=#{limiter}:attack=5:release=50:level=false:latency=true"
+			end
+			
+			def run(*arguments)
+				_output, error, status = Open3.capture3(
+					@command,
+					"-hide_banner",
+					"-nostats",
+					"-nostdin",
+					*arguments,
+				)
+				
+				unless status.success?
+					raise Error, error.lines.last(20).join
+				end
+				
+				return error
+			rescue Errno::ENOENT
+				raise Error, "Could not execute #{@command.inspect}; install FFmpeg or specify command:!"
+			end
+		end
+	end
+end

--- a/public/_static/index.css
+++ b/public/_static/index.css
@@ -460,6 +460,10 @@ body.playback[data-controls="false"] .playback-controls {
 	display: none;
 }
 
+body.playback[data-controls="false"] .playback-start-screen {
+	display: none;
+}
+
 .playback-controls button {
 	min-width: 2.4rem;
 	height: 2.2rem;

--- a/public/_static/index.css
+++ b/public/_static/index.css
@@ -331,6 +331,10 @@ live-view:has(.display) {
 	view-transition-name: slide-container;
 }
 
+.playback-stage {
+	view-transition-name: slide-container;
+}
+
 /* Default: no animation for the container (instant swap) */
 ::view-transition-old(slide-container),
 ::view-transition-new(slide-container) {
@@ -362,6 +366,119 @@ html[data-transition="slide-right"]::view-transition-old(slide-container) {
 
 html[data-transition="slide-right"]::view-transition-new(slide-container) {
 	animation: vt-slide-in-left 0.4s ease-in-out;
+}
+
+/* ========================
+   PLAYBACK
+   ======================== */
+
+body.playback,
+.playback-stage,
+.playback-frame,
+.playback-frame > .slide {
+	width: 100vw;
+	height: 100vh;
+}
+
+.playback-stage {
+	position: relative;
+	background: var(--slide-bg);
+}
+
+.playback-frame {
+	position: absolute;
+	inset: 0;
+}
+
+.playback-start-screen {
+	position: fixed;
+	inset: 0;
+	z-index: 100;
+	display: flex;
+	flex-direction: column;
+	align-items: center;
+	justify-content: center;
+	gap: 1rem;
+	background: rgba(5, 8, 20, 0.88);
+	backdrop-filter: blur(12px);
+}
+
+.playback-start-screen[hidden] {
+	display: none;
+}
+
+.playback-start {
+	padding: 0.9rem 1.4rem;
+	border: 1px solid rgba(255, 255, 255, 0.2);
+	border-radius: 0.6rem;
+	background: var(--accent);
+	color: white;
+	font: inherit;
+	font-size: 1.1rem;
+	cursor: pointer;
+}
+
+.playback-start:disabled {
+	opacity: 0.5;
+	cursor: default;
+}
+
+.playback-status {
+	margin: 0;
+	opacity: 0.75;
+}
+
+.playback-status.error {
+	color: var(--behind);
+	opacity: 1;
+}
+
+.playback-controls {
+	position: fixed;
+	left: 50%;
+	bottom: 1.25rem;
+	z-index: 90;
+	display: flex;
+	align-items: center;
+	gap: 0.5rem;
+	padding: 0.5rem 0.7rem;
+	transform: translateX(-50%);
+	border: 1px solid rgba(255, 255, 255, 0.12);
+	border-radius: 0.7rem;
+	background: rgba(5, 8, 20, 0.72);
+	backdrop-filter: blur(8px);
+	opacity: 0.2;
+	transition: opacity 160ms ease;
+}
+
+.playback-controls:hover,
+.playback-controls:focus-within {
+	opacity: 1;
+}
+
+body.playback[data-controls="false"] .playback-controls {
+	display: none;
+}
+
+.playback-controls button {
+	min-width: 2.4rem;
+	height: 2.2rem;
+	border: 0;
+	border-radius: 0.35rem;
+	background: rgba(255, 255, 255, 0.1);
+	color: white;
+	cursor: pointer;
+}
+
+.playback-controls button:disabled {
+	opacity: 0.3;
+	cursor: default;
+}
+
+.playback-counter {
+	min-width: 4rem;
+	text-align: center;
+	font-variant-numeric: tabular-nums;
 }
 
 @keyframes vt-fade-out {
@@ -702,6 +819,164 @@ html[data-transition="slide-right"]::view-transition-new(slide-container) {
 .notes .no-notes {
 	opacity: 0.4;
 	font-style: italic;
+}
+
+/* ========================
+   RECORDING VIEW
+   ======================== */
+
+.recorder {
+	width: 100vw;
+	height: 100vh;
+	display: grid;
+	grid-template-rows: auto 1fr;
+	gap: 0.75rem;
+	padding: 0.75rem;
+	background: #0d0d1a;
+}
+
+.recording-workspace {
+	display: grid;
+	grid-template-columns: minmax(0, 2fr) minmax(20rem, 1fr);
+	gap: 0.75rem;
+	min-height: 0;
+}
+
+.recording-preview {
+	position: relative;
+	min-height: 0;
+	overflow: hidden;
+	background: var(--slide-bg);
+	border: 2px solid var(--accent);
+	border-radius: 8px;
+}
+
+.recording-sidebar {
+	display: grid;
+	grid-template-rows: auto 1fr;
+	gap: 0.75rem;
+	min-height: 0;
+}
+
+.recording-panel,
+.recording-notes {
+	padding: 1rem;
+	background: var(--surface);
+	border-radius: 8px;
+}
+
+.recording-panel h2,
+.recording-notes h2 {
+	margin: 0 0 0.5rem;
+	font-size: 1rem;
+	letter-spacing: 0.05em;
+	text-transform: uppercase;
+}
+
+.recording-panel > p {
+	margin: 0 0 1rem;
+	opacity: 0.65;
+}
+
+presently-recorder {
+	display: grid;
+	gap: 1rem;
+}
+
+.recording-actions {
+	display: flex;
+	align-items: center;
+	gap: 0.6rem;
+}
+
+.recording-actions button {
+	padding: 0.55rem 0.9rem;
+	background: var(--surface-light);
+	border: 1px solid rgba(255,255,255,0.12);
+	border-radius: 6px;
+	color: var(--slide-text);
+	cursor: pointer;
+	font: inherit;
+}
+
+.recording-actions button:hover:not(:disabled) {
+	background: var(--accent);
+}
+
+.recording-actions button:disabled {
+	cursor: default;
+	opacity: 0.35;
+}
+
+.recording-start:not(:disabled) {
+	color: var(--accent-light);
+}
+
+.recording-indicator {
+	width: 0.65rem;
+	height: 0.65rem;
+	margin-left: auto;
+	background: rgba(255,255,255,0.2);
+	border-radius: 50%;
+}
+
+presently-recorder[data-state="preparing"] .recording-indicator,
+presently-recorder[data-state="starting"] .recording-indicator {
+	background: #f5b942;
+	box-shadow: 0 0 0 0.25rem rgba(245,185,66,0.15);
+	animation: recording-indicator-pulse 600ms ease-in-out infinite alternate;
+}
+
+presently-recorder[data-state="recording"] .recording-indicator {
+	background: #ef5350;
+	box-shadow: 0 0 0 0.25rem rgba(239,83,80,0.15);
+}
+
+@keyframes recording-indicator-pulse {
+	to {
+		opacity: 0.45;
+		transform: scale(0.8);
+	}
+}
+
+.recording-time {
+	font-family: var(--font-mono);
+	font-variant-numeric: tabular-nums;
+}
+
+.recording-playback {
+	width: 100%;
+}
+
+.recording-status {
+	min-height: 1.4em;
+	margin: 0;
+	font-size: 0.9rem;
+	opacity: 0.7;
+}
+
+.recording-status.error {
+	color: var(--behind);
+	opacity: 1;
+}
+
+.recording-notes {
+	min-height: 0;
+	overflow-y: auto;
+	font-size: 1.05rem;
+	line-height: 1.5;
+}
+
+.recording-notes p {
+	margin: 0.4em 0;
+}
+
+@media (max-width: 900px) {
+	.recording-workspace {
+		grid-template-columns: 1fr;
+		grid-template-rows: minmax(20rem, 1fr) auto;
+		overflow-y: auto;
+	}
 }
 
 /* ========================

--- a/public/application.js
+++ b/public/application.js
@@ -3,6 +3,281 @@ import Syntax from '@socketry/syntax';
 import { runScript } from './slide-scripts.js';
 import { applyCodeFocus } from './code-focus.js';
 
+const RECORDING_EDGE_DELAY = 100;
+
+// Records and reviews the narration for one slide. The element is recreated
+// when the selected slide changes, which gives each recording session a clear
+// lifetime and releases the microphone during navigation.
+class PresentlyRecorder extends HTMLElement {
+	#mediaRecorder = null;
+	#mediaStream = null;
+	#audioContext = null;
+	#audioSource = null;
+	#audioDelay = null;
+	#audioDestination = null;
+	#chunks = [];
+	#recording = null;
+	#recordingURL = null;
+	#startedAt = null;
+	#timer = null;
+	#startToken = null;
+	
+	connectedCallback() {
+		this.startButton = this.querySelector('.recording-start');
+		this.stopButton = this.querySelector('.recording-stop');
+		this.saveButton = this.querySelector('.recording-save');
+		this.playback = this.querySelector('.recording-playback');
+		this.status = this.querySelector('.recording-status');
+		this.time = this.querySelector('.recording-time');
+		
+		this.startButton.addEventListener('click', () => this.start(performance.now()));
+		// Stop as soon as the pointer is pressed, before the normal click completes.
+		// The click handler remains for keyboard activation and is safe to invoke twice.
+		this.stopButton.addEventListener('pointerdown', () => this.stop());
+		this.stopButton.addEventListener('click', () => this.stop());
+		this.saveButton.addEventListener('click', () => this.save());
+		
+		this.loadExisting();
+	}
+	
+	disconnectedCallback() {
+		this.#startToken = null;
+
+		if (this.#mediaRecorder?.state === 'recording') {
+			this.#mediaRecorder.onstop = null;
+			this.#mediaRecorder.stop();
+		}
+		
+		this.releaseMicrophone();
+		this.stopTimer();
+		this.releaseRecordingURL();
+	}
+	
+	get url() {
+		return this.dataset.recordingUrl;
+	}
+	
+	async loadExisting() {
+		try {
+			const response = await fetch(this.url, {method: 'HEAD', cache: 'no-store'});
+			
+			if (response.ok) {
+				this.playback.src = this.cacheBustedURL();
+				this.playback.hidden = false;
+				this.startButton.textContent = '● Retake';
+				this.setStatus('Existing recording loaded.');
+			} else if (response.status === 404) {
+				this.setStatus('No recording yet.');
+			} else {
+				throw new Error(`Could not check recording (${response.status}).`);
+			}
+		} catch (error) {
+			this.setStatus(error.message, true);
+		}
+	}
+	
+	async start(clickedAt) {
+		const AudioContext = window.AudioContext || window.webkitAudioContext;
+		if (!window.MediaRecorder || !navigator.mediaDevices?.getUserMedia || !AudioContext) {
+			this.setStatus('Audio recording is not supported by this browser.', true);
+			return;
+		}
+		
+		const mimeType = 'audio/webm;codecs=opus';
+		if (!MediaRecorder.isTypeSupported(mimeType)) {
+			this.setStatus(`${mimeType} recording is not supported by this browser.`, true);
+			return;
+		}
+		
+		const startToken = this.#startToken = {};
+		this.startButton.disabled = true;
+		this.stopButton.disabled = true;
+		this.saveButton.disabled = true;
+		this.dataset.state = 'preparing';
+		this.setStatus('Preparing microphone…');
+
+		try {
+			this.playback.pause();
+			this.#audioContext = new AudioContext();
+			await this.#audioContext.resume();
+
+			if (this.#startToken !== startToken || !this.isConnected) {
+				this.releaseMicrophone();
+				return;
+			}
+
+			const audio = {};
+			if (navigator.mediaDevices.getSupportedConstraints().autoGainControl) {
+				// Preserve the microphone's dynamics for consistent offline normalization.
+				audio.autoGainControl = false;
+			}
+
+			const mediaStream = await navigator.mediaDevices.getUserMedia({audio});
+
+			if (this.#startToken !== startToken || !this.isConnected) {
+				mediaStream.getTracks().forEach(track => track.stop());
+				this.releaseMicrophone();
+				return;
+			}
+
+			this.#mediaStream = mediaStream;
+			this.#audioSource = this.#audioContext.createMediaStreamSource(mediaStream);
+
+			this.#audioDelay = this.#audioContext.createDelay(RECORDING_EDGE_DELAY / 1000);
+			this.#audioDelay.delayTime.value = RECORDING_EDGE_DELAY / 1000;
+			this.#audioDestination = this.#audioContext.createMediaStreamDestination();
+			this.#audioSource
+				.connect(this.#audioDelay)
+				.connect(this.#audioDestination);
+
+			this.#chunks = [];
+			this.#mediaRecorder = new MediaRecorder(this.#audioDestination.stream, {mimeType});
+			
+			this.#mediaRecorder.addEventListener('dataavailable', (event) => {
+				if (event.data.size > 0) this.#chunks.push(event.data);
+			});
+			
+			this.#mediaRecorder.addEventListener('stop', () => this.finish());
+
+			this.dataset.state = 'starting';
+			this.setStatus('Starting…');
+
+			// Audio reaches MediaRecorder 100 ms after it reaches the microphone. Starting
+			// the encoder 200 ms after the click therefore retains audio beginning 100 ms
+			// after pointer-up. If microphone setup took longer, wait only long enough for
+			// the newly-created delay line to contain live audio.
+			const startAt = Math.max(
+				clickedAt + RECORDING_EDGE_DELAY * 2,
+				performance.now() + RECORDING_EDGE_DELAY,
+			);
+			await new Promise(resolve => window.setTimeout(resolve, Math.max(0, startAt - performance.now())));
+
+			if (this.#startToken !== startToken || !this.isConnected) return;
+
+			this.#mediaRecorder.start();
+			this.#startToken = null;
+			this.startTimer();
+			
+			this.stopButton.disabled = false;
+			this.dataset.state = 'recording';
+			this.setStatus('Recording…');
+		} catch (error) {
+			if (this.#startToken !== startToken) return;
+
+			this.#startToken = null;
+			this.releaseMicrophone();
+			this.startButton.disabled = false;
+			this.dataset.state = 'idle';
+			this.setStatus(`Could not start recording: ${error.message}`, true);
+		}
+	}
+	
+	stop() {
+		if (this.#mediaRecorder?.state === 'recording') {
+			// The encoder receives audio through a 100 ms delay. Stopping immediately
+			// excludes approximately the final 100 ms before this pointer-down event.
+			this.#mediaRecorder.stop();
+			this.stopButton.disabled = true;
+			this.dataset.state = 'finishing';
+			this.setStatus('Preparing recording…');
+		}
+	}
+	
+	finish() {
+		this.stopTimer();
+		this.releaseMicrophone();
+		this.releaseRecordingURL();
+		
+		this.#recording = new Blob(this.#chunks, {type: 'audio/webm'});
+		this.#recordingURL = URL.createObjectURL(this.#recording);
+		this.playback.src = this.#recordingURL;
+		this.playback.hidden = false;
+		
+		this.startButton.disabled = false;
+		this.startButton.textContent = '● Retake';
+		this.saveButton.disabled = this.#recording.size === 0;
+		this.dataset.state = 'review';
+		this.setStatus(this.#recording.size > 0 ? 'Review the recording, then save it.' : 'The recording was empty.', this.#recording.size === 0);
+	}
+	
+	async save() {
+		if (!this.#recording) return;
+		
+		this.saveButton.disabled = true;
+		this.setStatus('Saving…');
+		
+		try {
+			const response = await fetch(this.url, {
+				method: 'PUT',
+				headers: {'content-type': this.#recording.type},
+				body: this.#recording,
+			});
+			
+			if (!response.ok) {
+				throw new Error((await response.text()) || `Could not save recording (${response.status}).`);
+			}
+			
+			this.playback.src = this.cacheBustedURL();
+			this.releaseRecordingURL();
+			this.#recording = null;
+			this.setStatus('Recording saved.');
+		} catch (error) {
+			this.saveButton.disabled = false;
+			this.setStatus(`Could not save recording: ${error.message}`, true);
+		}
+	}
+	
+	startTimer() {
+		this.#startedAt = performance.now();
+		this.updateTimer();
+		this.#timer = window.setInterval(() => this.updateTimer(), 250);
+	}
+	
+	stopTimer() {
+		if (this.#timer) window.clearInterval(this.#timer);
+		this.#timer = null;
+	}
+	
+	updateTimer() {
+		const elapsed = Math.floor((performance.now() - this.#startedAt) / 1000);
+		const minutes = Math.floor(elapsed / 60);
+		const seconds = String(elapsed % 60).padStart(2, '0');
+		this.time.textContent = `${minutes}:${seconds}`;
+	}
+	
+	releaseMicrophone() {
+		this.#mediaStream?.getTracks().forEach(track => track.stop());
+		this.#mediaStream = null;
+
+		this.#audioDestination?.stream.getTracks().forEach(track => track.stop());
+		this.#audioSource?.disconnect();
+		this.#audioDelay?.disconnect();
+		this.#audioDestination?.disconnect();
+		this.#audioContext?.close().catch(() => {});
+
+		this.#audioContext = null;
+		this.#audioSource = null;
+		this.#audioDelay = null;
+		this.#audioDestination = null;
+	}
+	
+	releaseRecordingURL() {
+		if (this.#recordingURL) URL.revokeObjectURL(this.#recordingURL);
+		this.#recordingURL = null;
+	}
+	
+	cacheBustedURL() {
+		return `${this.url}&version=${Date.now()}`;
+	}
+	
+	setStatus(message, error = false) {
+		this.status.textContent = message;
+		this.status.classList.toggle('error', error);
+	}
+}
+
+customElements.define('presently-recorder', PresentlyRecorder);
+
 const live = Live.start();
 
 async function highlightAndApplyCodeFocus() {
@@ -89,6 +364,8 @@ document.addEventListener('change', (event) => {
 
 // Keyboard navigation
 document.addEventListener('keydown', (event) => {
+	if (event.target.closest('button, input, textarea, select, audio, presently-recorder')) return;
+	
 	const liveView = document.querySelector('live-view');
 	if (!liveView) return;
 	

--- a/public/application.js
+++ b/public/application.js
@@ -137,7 +137,7 @@ class PresentlyRecorder extends HTMLElement {
 				if (event.data.size > 0) this.#chunks.push(event.data);
 			});
 			
-			this.#mediaRecorder.addEventListener('stop', () => this.finish());
+			this.#mediaRecorder.onstop = () => this.finish();
 
 			this.dataset.state = 'starting';
 			this.setStatus('Starting…');

--- a/public/playback.js
+++ b/public/playback.js
@@ -1,0 +1,258 @@
+import Syntax from '@socketry/syntax';
+import {runScript} from './slide-scripts.js';
+import {applyCodeFocus} from './code-focus.js';
+
+const frames = Array.from(document.querySelectorAll('.playback-frame'));
+const audioTracks = new Map(
+	Array.from(document.querySelectorAll('.playback-audio audio')).map(audio => [Number(audio.dataset.index), audio]),
+);
+const startScreen = document.querySelector('.playback-start-screen');
+const startButton = document.querySelector('.playback-start');
+const status = document.querySelector('.playback-status');
+const previousButton = document.querySelector('.playback-previous');
+const toggleButton = document.querySelector('.playback-toggle');
+const nextButton = document.querySelector('.playback-next');
+const counter = document.querySelector('.playback-counter');
+
+let currentIndex = 0;
+let currentScript = null;
+let currentAudio = null;
+let playing = false;
+let transitioning = false;
+
+function setStatus(message, error = false) {
+	status.textContent = message;
+	status.classList.toggle('error', error);
+}
+
+function updateControls() {
+	toggleButton.textContent = playing ? '❚❚' : '▶';
+	previousButton.disabled = currentIndex === 0;
+	nextButton.disabled = currentIndex === frames.length - 1;
+	counter.textContent = `${currentIndex + 1} / ${frames.length}`;
+}
+
+function stopCurrent() {
+	currentScript?.cancelTimeouts();
+	currentScript = null;
+
+	if (currentAudio) {
+		currentAudio.pause();
+		currentAudio.removeEventListener('ended', handleEnded);
+		currentAudio = null;
+	}
+}
+
+function activateFrame(index) {
+	frames.forEach((frame, frameIndex) => {
+		frame.hidden = frameIndex !== index;
+	});
+
+	currentIndex = index;
+	const slide = frames[index].querySelector('.slide');
+	currentScript = runScript(slide);
+	updateControls();
+}
+
+async function show(index, {transition = true} = {}) {
+	if (transitioning || index < 0 || index >= frames.length) return false;
+
+	transitioning = true;
+	stopCurrent();
+
+	const transitionName = frames[index].dataset.transition;
+	const swap = () => activateFrame(index);
+
+	try {
+		if (transition && transitionName && document.startViewTransition) {
+			document.documentElement.dataset.transition = transitionName;
+			const viewTransition = document.startViewTransition(swap);
+			await viewTransition.updateCallbackDone;
+		} else {
+			swap();
+		}
+	} finally {
+		delete document.documentElement.dataset.transition;
+		transitioning = false;
+	}
+
+	return true;
+}
+
+function finish() {
+	stopCurrent();
+	playing = false;
+	updateControls();
+
+	if (document.body.dataset.controls !== 'false') {
+		startScreen.hidden = false;
+		startButton.disabled = false;
+		startButton.textContent = '↻ Play again';
+		setStatus('Playback complete.');
+	}
+
+	window.__PRESENTLY_PLAYBACK_FINISHED = true;
+	document.dispatchEvent(new CustomEvent('presently:playback-finished'));
+}
+
+async function playCurrent() {
+	currentAudio = audioTracks.get(currentIndex);
+
+	if (!currentAudio) {
+		playing = false;
+		updateControls();
+		startScreen.hidden = false;
+		startButton.disabled = false;
+		setStatus(`Slide ${currentIndex + 1} has no narration.`, true);
+		throw new Error(`Slide ${currentIndex + 1} has no narration.`);
+	}
+
+	currentAudio.currentTime = 0;
+	currentAudio.addEventListener('ended', handleEnded, {once: true});
+	await currentAudio.play();
+	playing = true;
+	updateControls();
+}
+
+async function handleEnded() {
+	try {
+		if (currentIndex === frames.length - 1) {
+			finish();
+			return;
+		}
+
+		await show(currentIndex + 1);
+		await playCurrent();
+	} catch (error) {
+		handlePlaybackError(error);
+	}
+}
+
+function handlePlaybackError(error) {
+	stopCurrent();
+	playing = false;
+	updateControls();
+	startScreen.hidden = false;
+	startButton.disabled = false;
+	setStatus(error.name === 'NotAllowedError' ? 'Press Start to allow audio playback.' : error.message, error.name !== 'NotAllowedError');
+	console.error(error);
+}
+
+async function start() {
+	window.__PRESENTLY_PLAYBACK_FINISHED = false;
+	startButton.disabled = true;
+
+	try {
+		if (currentIndex === frames.length - 1 || startButton.textContent.includes('again')) {
+			await show(0, {transition: false});
+		}
+
+		startScreen.hidden = true;
+		await playCurrent();
+	} catch (error) {
+		handlePlaybackError(error);
+	}
+}
+
+async function move(offset) {
+	const wasPlaying = playing;
+	const index = Math.max(0, Math.min(frames.length - 1, currentIndex + offset));
+	if (index === currentIndex) return;
+
+	playing = false;
+	await show(index);
+	if (wasPlaying) {
+		try {
+			await playCurrent();
+		} catch (error) {
+			handlePlaybackError(error);
+		}
+	}
+}
+
+async function toggle() {
+	try {
+		if (!currentAudio || currentAudio.ended) {
+			startScreen.hidden = true;
+			await playCurrent();
+		} else if (currentAudio.paused) {
+			await currentAudio.play();
+			playing = true;
+			updateControls();
+		} else {
+			currentAudio.pause();
+			playing = false;
+			updateControls();
+		}
+	} catch (error) {
+		handlePlaybackError(error);
+	}
+}
+
+startButton.addEventListener('click', start);
+previousButton.addEventListener('click', () => move(-1));
+toggleButton.addEventListener('click', toggle);
+nextButton.addEventListener('click', () => move(1));
+
+document.addEventListener('keydown', async event => {
+	if (event.target.closest('button')) return;
+
+	switch (event.key) {
+		case 'ArrowLeft':
+		case 'PageUp':
+			event.preventDefault();
+			await move(-1);
+			break;
+		case 'ArrowRight':
+		case 'PageDown':
+			event.preventDefault();
+			await move(1);
+			break;
+		case ' ':
+			event.preventDefault();
+			await toggle();
+			break;
+		case 'f':
+		case 'F':
+			event.preventDefault();
+			if (document.fullscreenElement) await document.exitFullscreen();
+			else await document.documentElement.requestFullscreen();
+			break;
+	}
+});
+
+async function waitForAudioMetadata(audio) {
+	if (audio.readyState >= HTMLMediaElement.HAVE_METADATA) return;
+
+	await new Promise((resolve, reject) => {
+		audio.addEventListener('loadedmetadata', resolve, {once: true});
+		audio.addEventListener('error', () => reject(new Error(`Could not load narration for slide ${Number(audio.dataset.index) + 1}.`)), {once: true});
+	});
+}
+
+async function prepare() {
+	if (!frames.length) throw new Error('The presentation has no slides.');
+	if (audioTracks.size !== frames.length) throw new Error('Every slide requires a narration recording.');
+
+	await Promise.all([
+		Syntax.highlight(),
+		document.fonts.ready,
+		...Array.from(audioTracks.values()).map(waitForAudioMetadata),
+	]);
+	await applyCodeFocus();
+
+	activateFrame(0);
+	startButton.disabled = false;
+	setStatus('Ready.');
+
+	window.__PRESENTLY_PLAYBACK_READY = true;
+	document.dispatchEvent(new CustomEvent('presently:playback-ready'));
+
+	if (document.body.dataset.autoplay === 'true') await start();
+}
+
+prepare().catch(error => {
+	startButton.disabled = true;
+	setStatus(error.message, true);
+	console.error(error);
+});

--- a/public/playback.js
+++ b/public/playback.js
@@ -136,10 +136,14 @@ function handlePlaybackError(error) {
 	startButton.disabled = false;
 	setStatus(error.name === 'NotAllowedError' ? 'Press Start to allow audio playback.' : error.message, error.name !== 'NotAllowedError');
 	console.error(error);
+
+	window.__PRESENTLY_PLAYBACK_ERROR = error.message;
+	document.dispatchEvent(new CustomEvent('presently:playback-error', {detail: {message: error.message}}));
 }
 
 async function start() {
 	window.__PRESENTLY_PLAYBACK_FINISHED = false;
+	window.__PRESENTLY_PLAYBACK_ERROR = null;
 	startButton.disabled = true;
 
 	try {
@@ -153,6 +157,8 @@ async function start() {
 		handlePlaybackError(error);
 	}
 }
+
+window.__PRESENTLY_PLAYBACK_START = start;
 
 async function move(offset) {
 	const wasPlaying = playing;
@@ -255,4 +261,7 @@ prepare().catch(error => {
 	startButton.disabled = true;
 	setStatus(error.message, true);
 	console.error(error);
+
+	window.__PRESENTLY_PLAYBACK_ERROR = error.message;
+	document.dispatchEvent(new CustomEvent('presently:playback-error', {detail: {message: error.message}}));
 });

--- a/readme.md
+++ b/readme.md
@@ -14,6 +14,8 @@ A web-based presentation tool built with [Lively](https://github.com/socketry/li
   - **Code highlighting** with [@socketry/syntax](https://github.com/socketry/syntax-js), including animated focus regions for code walkthroughs.
   - **Multiple templates** — title, section, two-column, code, translation, image, and default.
   - **Timing and pacing** — per-slide duration metadata with elapsed/remaining time and pacing indicators.
+  - **Slide narration** — record, review, and retake one audio track per slide from a dedicated recording interface.
+  - **Narrated playback** — automatically play each slide with its recorded narration, including slide scripts and transitions.
   - **Full-screen support** — press `F` on the display view.
   - **Keyboard navigation** — arrow keys, space, Page Up/Down.
 
@@ -24,6 +26,29 @@ Please see the [project documentation](https://socketry.github.io/presently/) fo
   - [Getting Started](https://socketry.github.io/presently/guides/getting-started/index) - This guide explains how to use `presently` to create and deliver web-based presentations using Markdown slides.
 
   - [Animating Slides](https://socketry.github.io/presently/guides/animating-slides/index) - This guide explains how to animate content within slides using the slide scripting system.
+
+### Recording Narration
+
+Open `http://localhost:9292/record` to record narration separately from the live presenter interface. Presently stores one WebM/Opus recording per slide under `audio/`, mirroring the slide's relative path:
+
+``` text
+slides/020-problem/010-overview.md
+audio/020-problem/010-overview.webm
+```
+
+The interface preserves the microphone's dynamics for offline normalization and excludes mouse clicks at the recording boundaries using a short delayed audio pipeline. An existing recording is preserved until a completed retake is explicitly saved.
+
+After recording, normalize every completed take to a consistent `-16 LUFS` target:
+
+``` shell
+bundle exec bake presently:recordings:normalize
+```
+
+The task preserves the original files under `audio/` and writes normalized copies to matching paths under `audio-normalized/`. It requires FFmpeg.
+
+Open `http://localhost:9292/playback` to watch the narrated presentation. Playback uses normalized audio when available, falls back to the original recording, and advances when each track ends.
+
+For automated capture, use `http://localhost:9292/playback?autoplay=true&controls=false`. The page exposes `window.__PRESENTLY_PLAYBACK_READY` and `window.__PRESENTLY_PLAYBACK_FINISHED`, and dispatches matching `presently:playback-ready` and `presently:playback-finished` events.
 
 ## Releases
 

--- a/readme.md
+++ b/readme.md
@@ -50,6 +50,16 @@ Open `http://localhost:9292/playback` to watch the narrated presentation. Playba
 
 For automated capture, use `http://localhost:9292/playback?autoplay=true&controls=false`. The page exposes `window.__PRESENTLY_PLAYBACK_READY` and `window.__PRESENTLY_PLAYBACK_FINISHED`, and dispatches matching `presently:playback-ready` and `presently:playback-finished` events.
 
+To export playback directly to an MP4 file using a Chromium build that supports `Page.startScreenRecording`:
+
+``` shell
+PRESENTLY_CHROME_PATH=/path/to/chromium \
+PRESENTLY_CHROMEDRIVER_PATH=/path/to/chromedriver \
+bundle exec bake presently:export:video output=presentation.mp4
+```
+
+The task records the presentation at 1920×1080 and 30 frames per second by default. Use `width`, `height`, and `frame_rate` to select different limits. If explicit browser paths are omitted, Presently tries the current Chrome for Testing canary build.
+
 ## Releases
 
 Please see the [project releases](https://socketry.github.io/presently/releases/index) for all releases.

--- a/test/presently/application.rb
+++ b/test/presently/application.rb
@@ -1,0 +1,115 @@
+# frozen_string_literal: true
+
+# Released under the MIT License.
+# Copyright, 2026, by Samuel Williams.
+
+require "presently/application"
+require "protocol/http/body/buffered"
+require "protocol/http/middleware"
+require "tmpdir"
+require "fileutils"
+
+describe Presently::Application do
+	let(:dir) {Dir.mktmpdir}
+	let(:slides_root) {File.join(dir, "slides")}
+	let(:recordings_root) {File.join(dir, "audio")}
+	let(:playback_recordings_root) {File.join(dir, "audio-normalized")}
+	let(:application) do
+		subject.new(
+			Protocol::HTTP::Middleware::NotFound,
+			slides_root: slides_root,
+			recordings_root: recordings_root,
+			playback_recordings_root: playback_recordings_root,
+		)
+	end
+	
+	before do
+		FileUtils.mkdir_p(slides_root)
+		File.write(File.join(slides_root, "010-example.md"), "Example slide\n")
+	end
+	
+	after do
+		FileUtils.remove_entry(dir)
+	end
+	
+	def request(method, path, headers = {}, body = nil)
+		Protocol::HTTP::Request[method, path, headers, Protocol::HTTP::Body::Buffered.wrap(body)]
+	end
+	
+	it "serves the recording interface separately from the presenter" do
+		response = application.handle(request("GET", "/record"))
+		
+		expect(response.status).to be == 200
+		expect(response.read).to be(:include?, "Record, review, and save one audio track")
+	end
+	
+	it "stores and serves a slide recording" do
+		put = application.handle(request("PUT", "/recordings?index=0", {"content-type" => "audio/webm;codecs=opus"}, "audio data"))
+		expect(put.status).to be == 201
+		
+		get = application.handle(request("GET", "/recordings?index=0"))
+		expect(get.status).to be == 200
+		expect(get.headers["content-type"]).to be == "audio/webm"
+		expect(get.read).to be == "audio data"
+	end
+	
+	it "supports checking for a recording without returning its body" do
+		application.handle(request("PUT", "/recordings?index=0", {"content-type" => "audio/webm"}, "audio data"))
+		response = application.handle(request("HEAD", "/recordings?index=0"))
+		
+		expect(response.status).to be == 200
+		expect(response.body).to be_nil
+	end
+	
+	it "rejects unsupported recording formats" do
+		response = application.handle(request("PUT", "/recordings?index=0", {"content-type" => "audio/mpeg"}, "audio data"))
+		expect(response.status).to be == 415
+	end
+	
+	it "rejects an invalid slide index" do
+		expect(application.handle(request("GET", "/recordings")).status).to be == 400
+		expect(application.handle(request("GET", "/recordings?index=20")).status).to be == 404
+	end
+	
+	it "serves the playback interface" do
+		FileUtils.mkdir_p(recordings_root)
+		File.binwrite(File.join(recordings_root, "010-example.webm"), "source audio")
+		
+		response = application.handle(request("GET", "/playback?autoplay=true&controls=false"))
+		html = response.read
+		
+		expect(response.status).to be == 200
+		expect(html).to be(:include?, "playback.js")
+		expect(html).to be(:include?, 'data-autoplay="true"')
+		expect(html).to be(:include?, "/playback/recordings?index=0")
+	end
+	
+	it "prefers normalized narration for playback" do
+		FileUtils.mkdir_p(recordings_root)
+		FileUtils.mkdir_p(playback_recordings_root)
+		File.binwrite(File.join(recordings_root, "010-example.webm"), "source audio")
+		File.binwrite(File.join(playback_recordings_root, "010-example.webm"), "normalized audio")
+		
+		response = application.handle(request("GET", "/playback/recordings?index=0"))
+		
+		expect(response.status).to be == 200
+		expect(response.read).to be == "normalized audio"
+	end
+	
+	it "falls back to source narration for playback" do
+		FileUtils.mkdir_p(recordings_root)
+		File.binwrite(File.join(recordings_root, "010-example.webm"), "source audio")
+		
+		response = application.handle(request("GET", "/playback/recordings?index=0"))
+		
+		expect(response.status).to be == 200
+		expect(response.read).to be == "source audio"
+	end
+	
+	it "only reads playback narration" do
+		response = application.handle(request("PUT", "/playback/recordings?index=0"))
+		
+		expect(response.status).to be == 405
+		expect(response.headers["allow"]).to be == ["GET", "HEAD"]
+	end
+end

--- a/test/presently/playback.rb
+++ b/test/presently/playback.rb
@@ -1,0 +1,63 @@
+# frozen_string_literal: true
+
+# Released under the MIT License.
+# Copyright, 2026, by Samuel Williams.
+
+require "presently/playback"
+require "presently/presentation"
+require "tmpdir"
+require "fileutils"
+
+describe Presently::Playback do
+	let(:dir) {Dir.mktmpdir}
+	
+	after do
+		FileUtils.remove_entry(dir)
+	end
+	
+	before do
+		File.write(File.join(dir, "01.md"), "First slide\n")
+		File.write(File.join(dir, "02.md"), "Second slide\n")
+	end
+	
+	let(:presentation) {Presently::Presentation.load(dir)}
+	let(:recording_urls) {["/recordings?index=0", "/recordings?index=1"]}
+	let(:playback) {subject.new(presentation: presentation, recording_urls: recording_urls)}
+	
+	with ".options_from_query" do
+		it "uses interactive playback by default" do
+			expect(subject.options_from_query(nil)).to be == {autoplay: false, controls: true}
+		end
+		
+		it "parses autoplay and controls" do
+			expect(subject.options_from_query("autoplay=true&controls=false")).to be == {autoplay: true, controls: false}
+		end
+	end
+	
+	with "#call" do
+		it "renders every slide and narration track" do
+			html = playback.call
+			
+			expect(html).to be(:include?, "First slide")
+			expect(html).to be(:include?, "Second slide")
+			expect(html.scan("<audio ").size).to be == 2
+		end
+		
+		it "loads the playback controller" do
+			expect(playback.call).to be(:include?, "playback.js")
+		end
+		
+		it "omits an unavailable narration track" do
+			playback = subject.new(presentation: presentation, recording_urls: [recording_urls.first, nil])
+			
+			expect(playback.call.scan("<audio ").size).to be == 1
+		end
+		
+		it "embeds playback options" do
+			playback = subject.new(presentation: presentation, recording_urls: recording_urls, autoplay: true, controls: false)
+			
+			expect(playback.call).to be(:include?, 'data-autoplay="true"')
+			expect(playback.call).to be(:include?, 'data-controls="false"')
+		end
+	end
+end

--- a/test/presently/recording_view.rb
+++ b/test/presently/recording_view.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+# Released under the MIT License.
+# Copyright, 2026, by Samuel Williams.
+
+require "presently/page"
+require "presently/presentation"
+require "presently/presentation_controller"
+require "presently/recording_view"
+require "tmpdir"
+require "fileutils"
+
+describe Presently::RecordingView do
+	let(:dir) {Dir.mktmpdir}
+	let(:path) {File.join(dir, "010-example.md")}
+	let(:presentation) {Presently::Presentation.load(dir)}
+	let(:controller) {Presently::PresentationController.new(presentation)}
+	let(:view) {subject.new(controller: controller)}
+	
+	before do
+		File.write(path, "---\nmarker: Example\n---\nExample slide\n\n---\nNarrate this slide.\n")
+	end
+	
+	after do
+		FileUtils.remove_entry(dir)
+	end
+	
+	it "renders a dedicated recording interface" do
+		html = Presently::Page.new(body: view).call
+		
+		expect(html).to be(:include?, "Example slide")
+		expect(html).to be(:include?, "Narrate this slide.")
+		expect(html).to be(:include?, "<presently-recorder")
+		expect(html).to be(:include?, 'data-recording-url="/recordings?index=0"')
+		expect(html).to be(:include?, "● Record")
+		expect(html).to be(:include?, 'class="recording-indicator"')
+	end
+	
+	it "navigates independently of the presenter interface" do
+		File.write(File.join(dir, "020-next.md"), "Next slide\n")
+		controller.reload!
+		
+		view.handle(detail: {action: "next"})
+		expect(controller.current_index).to be == 1
+	end
+end

--- a/test/presently/recordings.rb
+++ b/test/presently/recordings.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+# Released under the MIT License.
+# Copyright, 2026, by Samuel Williams.
+
+require "presently/presentation"
+require "presently/recordings"
+require "protocol/http/body/buffered"
+require "tmpdir"
+require "fileutils"
+
+describe Presently::Recordings do
+	let(:dir) {Dir.mktmpdir}
+	let(:slides_root) {File.join(dir, "slides")}
+	let(:recordings_root) {File.join(dir, "audio")}
+	let(:presentation) {Presently::Presentation.load(slides_root)}
+	let(:slide) {presentation.slides.first}
+	let(:recordings) {subject.new(recordings_root)}
+	
+	before do
+		FileUtils.mkdir_p(File.join(slides_root, "020-topic"))
+		File.write(File.join(slides_root, "020-topic", "010-example.md"), "Example\n")
+	end
+	
+	after do
+		FileUtils.remove_entry(dir)
+	end
+	
+	it "maps the slide path to a WebM recording path" do
+		expect(recordings.relative_path(slide)).to be == "020-topic/010-example.webm"
+		expect(recordings.path(slide)).to be == File.join(recordings_root, "020-topic", "010-example.webm")
+	end
+	
+	it "writes and reads the recording" do
+		body = Protocol::HTTP::Body::Buffered.wrap(["audio", " data"])
+		recordings.write(slide, body)
+		
+		expect(recordings).to be(:exist?, slide)
+		expect(recordings.read(slide).join).to be == "audio data"
+	end
+	
+	it "does not replace an existing recording when an upload is too large" do
+		FileUtils.mkdir_p(File.dirname(recordings.path(slide)))
+		File.binwrite(recordings.path(slide), "existing")
+		limited_recordings = subject.new(recordings_root, maximum_size: 4)
+		body = Protocol::HTTP::Body::Buffered.wrap("larger")
+		expect{limited_recordings.write(slide, body)}.to raise_exception(Presently::Recordings::TooLarge)
+		
+		expect(File.binread(recordings.path(slide))).to be == "existing"
+	end
+end


### PR DESCRIPTION
Adds an isolated narration workflow to Presently.

- Record, review, retake, and save one WebM/Opus track per slide at `/record`.
- Normalize recordings to -16 LUFS with `bake presently:recordings:normalize`, preserving the originals.
- Watch a complete narrated presentation at `/playback`; normalized recordings are preferred with source-recording fallback.
- Preserve slide scripts and view transitions during playback.
- Export narrated playback directly to MP4 with `bake presently:export:video`.
- Support capture automation through playback ready, start, finished, and error signals.

Validated with the Fantail deck in Chromium: all 14 tracks advanced through the final slide and produced an MP4 containing AV1 video and stereo Opus audio. Exact 1920x1080 viewport capture was also verified.

Checks:
- `bundle exec bake test`
- `bundle exec rubocop`
- `node --check public/playback.js`
- Existing `presently:export:pdf` task
- Narrated video export against the Fantail presentation