### PR TITLE
Use a single recording control

### DIFF
--- a/lib/presently/recording_view.rb
+++ b/lib/presently/recording_view.rb
@@ -95,8 +95,7 @@ module Presently
 								"data-recording-url": recording_url
 							) do
 								builder.tag(:div, class: "recording-actions") do
-									builder.tag(:button, class: "recording-start", type: "button"){builder.text("● Record")}
-									builder.tag(:button, class: "recording-stop", type: "button", disabled: true){builder.text("■ Stop")}
+									builder.tag(:button, class: "recording-toggle", type: "button"){builder.text("● Record")}
 									builder.tag(:button, class: "recording-save", type: "button", disabled: true){builder.text("Save")}
 									builder.tag(:span, class: "recording-indicator", "aria-hidden": "true"){}
 									builder.tag(:span, class: "recording-time"){builder.text("0:00")}

--- a/public/_static/index.css
+++ b/public/_static/index.css
@@ -912,8 +912,12 @@ presently-recorder {
 	opacity: 0.35;
 }
 
-.recording-start:not(:disabled) {
+.recording-toggle:not(:disabled) {
 	color: var(--accent-light);
+}
+
+presently-recorder[data-state="recording"] .recording-toggle {
+	color: #ef5350;
 }
 
 .recording-indicator {

--- a/public/recorder.js
+++ b/public/recorder.js
@@ -18,18 +18,26 @@ class PresentlyRecorder extends HTMLElement {
 	#startToken = null;
 	
 	connectedCallback() {
-		this.startButton = this.querySelector('.recording-start');
-		this.stopButton = this.querySelector('.recording-stop');
+		this.recordButton = this.querySelector('.recording-toggle');
 		this.saveButton = this.querySelector('.recording-save');
 		this.playback = this.querySelector('.recording-playback');
 		this.status = this.querySelector('.recording-status');
 		this.time = this.querySelector('.recording-time');
 		
-		this.startButton.addEventListener('click', () => this.start(performance.now()));
-		// Stop as soon as the pointer is pressed, before the normal click completes.
-		// The click handler remains for keyboard activation and is safe to invoke twice.
-		this.stopButton.addEventListener('pointerdown', () => this.stop());
-		this.stopButton.addEventListener('click', () => this.stop());
+		// Stop as soon as the pointer is pressed so the delayed audio excludes the
+		// click. The click handler provides both starting and keyboard activation.
+		this.recordButton.addEventListener('pointerdown', () => {
+			if (this.#mediaRecorder?.state === 'recording') this.stop();
+		});
+		this.recordButton.addEventListener('click', () => {
+			if (this.recordButton.disabled) return;
+			
+			if (this.#mediaRecorder?.state === 'recording') {
+				this.stop();
+			} else {
+				this.start(performance.now());
+			}
+		});
 		this.saveButton.addEventListener('click', () => this.save());
 		
 		this.loadExisting();
@@ -59,7 +67,7 @@ class PresentlyRecorder extends HTMLElement {
 			if (response.ok) {
 				this.playback.src = this.cacheBustedURL();
 				this.playback.hidden = false;
-				this.startButton.textContent = '● Retake';
+				this.recordButton.textContent = '● Retake';
 				this.setStatus('Existing recording loaded.');
 			} else if (response.status === 404) {
 				this.setStatus('No recording yet.');
@@ -85,8 +93,7 @@ class PresentlyRecorder extends HTMLElement {
 		}
 		
 		const startToken = this.#startToken = {};
-		this.startButton.disabled = true;
-		this.stopButton.disabled = true;
+		this.recordButton.disabled = true;
 		this.saveButton.disabled = true;
 		this.dataset.state = 'preparing';
 		this.setStatus('Preparing microphone…');
@@ -153,7 +160,8 @@ class PresentlyRecorder extends HTMLElement {
 			this.#startToken = null;
 			this.startTimer();
 			
-			this.stopButton.disabled = false;
+			this.recordButton.disabled = false;
+			this.recordButton.textContent = '■ Stop';
 			this.dataset.state = 'recording';
 			this.setStatus('Recording…');
 		} catch (error) {
@@ -161,7 +169,7 @@ class PresentlyRecorder extends HTMLElement {
 
 			this.#startToken = null;
 			this.releaseMicrophone();
-			this.startButton.disabled = false;
+			this.recordButton.disabled = false;
 			this.dataset.state = 'idle';
 			this.setStatus(`Could not start recording: ${error.message}`, true);
 		}
@@ -172,7 +180,7 @@ class PresentlyRecorder extends HTMLElement {
 			// The encoder receives audio through a 100 ms delay. Stopping immediately
 			// excludes approximately the final 100 ms before this pointer-down event.
 			this.#mediaRecorder.stop();
-			this.stopButton.disabled = true;
+			this.recordButton.disabled = true;
 			this.dataset.state = 'finishing';
 			this.setStatus('Preparing recording…');
 		}
@@ -188,8 +196,8 @@ class PresentlyRecorder extends HTMLElement {
 		this.playback.src = this.#recordingURL;
 		this.playback.hidden = false;
 		
-		this.startButton.disabled = false;
-		this.startButton.textContent = '● Retake';
+		this.recordButton.disabled = false;
+		this.recordButton.textContent = '● Retake';
 		this.saveButton.disabled = this.#recording.size === 0;
 		this.dataset.state = 'review';
 		this.setStatus(this.#recording.size > 0 ? 'Review the recording, then save it.' : 'The recording was empty.', this.#recording.size === 0);

--- a/test/presently/recording_view.rb
+++ b/test/presently/recording_view.rb
@@ -32,7 +32,9 @@ describe Presently::RecordingView do
 		expect(html).to be(:include?, "Narrate this slide.")
 		expect(html).to be(:include?, "<presently-recorder")
 		expect(html).to be(:include?, 'data-recording-url="/recordings?index=0"')
+		expect(html).to be(:include?, 'class="recording-toggle"')
 		expect(html).to be(:include?, "● Record")
+		expect(html).not.to be(:include?, 'class="recording-stop"')
 		expect(html).to be(:include?, 'class="recording-indicator"')
 	end
 	


### PR DESCRIPTION
## Summary

- toggle the recording button between Record/Retake and Stop
- stop on pointer-down so the existing audio-delay trimming excludes the final click
- retain click-based keyboard activation
- remove the separate stop button

## Validation

- `bundle exec bake test`
- `bundle exec rubocop`
- `node --check public/recorder.js`
- `git diff --check`