### PR TITLE
Add presentation interface launcher

### DIFF
--- a/guides/getting-started/readme.md
+++ b/guides/getting-started/readme.md
@@ -124,9 +124,10 @@ Start the server from your presentation directory:
 $ presently
 ```
 
-Then open two browser windows:
+Open the launcher, or go directly to one of the presentation interfaces:
 
-- `http://localhost:9292/` — the audience display.
+- `http://localhost:9292/` — the interface launcher.
+- `http://localhost:9292/display` — the audience display.
 - `http://localhost:9292/presenter` — the presenter console.
 - `http://localhost:9292/record` — the slide narration recorder.
 - `http://localhost:9292/playback` — automatic playback with recorded narration.

--- a/lib/presently/application.rb
+++ b/lib/presently/application.rb
@@ -69,20 +69,16 @@ module Presently
 			"Presently"
 		end
 		
-		# Create the home page for the root route.
-		# @returns [Page] The presentation interface launcher.
-		def index
-			Page.new(title: title, body: body)
-		end
-		
-		# Add Presently's routes to Lively's standard application routes.
+		# Add Presently's application routes.
 		# @parameter router [Lively::Router] The router to configure.
 		def configure_routes(router)
-			super
+			router.get("/") do |request|
+				Page.new(title: title, body: make_view(HomeView)).call(request)
+			end
 			
-			router.get("/display"){render_page(DisplayView.new(controller: controller))}
-			router.get("/presenter"){render_page(PresenterView.new(controller: controller))}
-			router.get("/record"){render_page(RecordingView.new(controller: controller))}
+			router.get("/display"){|request| render_view(request, DisplayView)}
+			router.get("/presenter"){|request| render_view(request, PresenterView)}
+			router.get("/record"){|request| render_view(request, RecordingView)}
 			
 			router.route("/recordings", methods: ["GET", "HEAD", "PUT"]) do |request, parameters|
 				handle_recording(request, parameters)
@@ -104,14 +100,11 @@ module Presently
 		private
 		
 		# Create a Presently page with the presentation-specific stylesheets.
-		def page(body)
+		# @parameter view [Live::View] The root view for the page.
+		# @returns [Page] The presentation page.
+		def make_page(view)
 			stylesheets = controller.presentation.stylesheets.map(&:url)
-			Page.new(title: title, body: body, stylesheets: stylesheets)
-		end
-		
-		# Render one of Presently's live interfaces.
-		def render_page(body)
-			Protocol::HTTP::Response[200, [], [page(body).call]]
+			Page.new(title: title, body: view, stylesheets: stylesheets)
 		end
 		
 		# Render the narrated playback interface.

--- a/lib/presently/application.rb
+++ b/lib/presently/application.rb
@@ -7,6 +7,7 @@ require "lively"
 
 require_relative "presentation"
 require_relative "presentation_controller"
+require_relative "home_view"
 require_relative "display_view"
 require_relative "presenter_view"
 require_relative "recording_view"
@@ -42,7 +43,7 @@ module Presently
 		# The view classes that this application allows.
 		# @returns [Array(Class)] The allowed view classes.
 		def allowed_views
-			[DisplayView, PresenterView, RecordingView]
+			[HomeView, DisplayView, PresenterView, RecordingView]
 		end
 		
 		# The shared state passed to all views via the resolver.
@@ -68,10 +69,10 @@ module Presently
 			"Presently"
 		end
 		
-		# Create the presentation display page for the root route.
-		# @returns [Page] The presentation page.
+		# Create the home page for the root route.
+		# @returns [Page] The presentation interface launcher.
 		def index
-			page(body)
+			Page.new(title: title, body: body)
 		end
 		
 		# Add Presently's routes to Lively's standard application routes.
@@ -79,6 +80,7 @@ module Presently
 		def configure_routes(router)
 			super
 			
+			router.get("/display"){render_page(DisplayView.new(controller: controller))}
 			router.get("/presenter"){render_page(PresenterView.new(controller: controller))}
 			router.get("/record"){render_page(RecordingView.new(controller: controller))}
 			

--- a/lib/presently/application.rb
+++ b/lib/presently/application.rb
@@ -4,6 +4,7 @@
 # Copyright, 2026, by Samuel Williams.
 
 require "lively"
+require "protocol/url"
 
 require_relative "presentation"
 require_relative "presentation_controller"
@@ -78,34 +79,42 @@ module Presently
 		end
 		
 		# Add Presently's application routes.
-		# @parameter router [Lively::Router] The router to configure.
+		# @parameter router [Lively::Router::Builder] The router to configure.
 		def configure_routes(router)
-			router.get("/") do |request|
-				Page.new(title: title, body: make_view(HomeView)).call(request)
+			router.get("/") do
+				body = resolver.root(HomeView)
+				Page.new(title: title, body: body).call
 			end
 			
-			router.get("/display"){|request| render_view(request, DisplayView)}
-			router.get("/presenter"){|request| render_view(request, PresenterView)}
-			router.get("/record"){|request| render_view(request, RecordingView)}
+			router.get("/display"){make_page(resolver.root(DisplayView)).call}
+			router.get("/presenter"){make_page(resolver.root(PresenterView)).call}
+			router.get("/record"){make_page(resolver.root(RecordingView)).call}
 			
-			router.route("/recordings", methods: ["GET", "HEAD", "PUT"]) do |request, parameters|
-				handle_recording(request, parameters)
+			router.route("/recordings", methods: ["GET", "HEAD", "PUT"]) do |request|
+				handle_recording(request, request_parameters(request))
 			end
 			
-			router.route("/playback/recordings", methods: ["GET", "HEAD"]) do |request, parameters|
-				handle_playback_recording(request, parameters)
+			router.route("/playback/recordings", methods: ["GET", "HEAD"]) do |request|
+				handle_playback_recording(request, request_parameters(request))
 			end
 			
-			router.get("/playback") do |_request, parameters|
-				render_playback(parameters)
+			router.get("/playback") do |request|
+				render_playback(request_parameters(request))
 			end
 			
-			router.get("/export") do |_request, parameters|
-				render_export(parameters)
+			router.get("/export") do |request|
+				render_export(request_parameters(request))
 			end
 		end
 		
 		private
+		
+		# Parse query parameters from the incoming request target.
+		# @parameter request [Protocol::HTTP::Request] The incoming request.
+		# @returns [Hash] The decoded query parameters.
+		def request_parameters(request)
+			Protocol::URL::Reference[request.path].parse_query!
+		end
 		
 		# Render the narrated playback interface.
 		def render_playback(parameters)

--- a/lib/presently/application.rb
+++ b/lib/presently/application.rb
@@ -69,6 +69,14 @@ module Presently
 			"Presently"
 		end
 		
+		# Create a Presently page with the presentation-specific stylesheets.
+		# @parameter view [Live::View] The root view for the page.
+		# @returns [Page] The presentation page.
+		def make_page(view)
+			stylesheets = controller.presentation.stylesheets.map(&:url)
+			Page.new(title: title, body: view, stylesheets: stylesheets)
+		end
+		
 		# Add Presently's application routes.
 		# @parameter router [Lively::Router] The router to configure.
 		def configure_routes(router)
@@ -98,14 +106,6 @@ module Presently
 		end
 		
 		private
-		
-		# Create a Presently page with the presentation-specific stylesheets.
-		# @parameter view [Live::View] The root view for the page.
-		# @returns [Page] The presentation page.
-		def make_page(view)
-			stylesheets = controller.presentation.stylesheets.map(&:url)
-			Page.new(title: title, body: view, stylesheets: stylesheets)
-		end
 		
 		# Render the narrated playback interface.
 		def render_playback(parameters)

--- a/lib/presently/display_view.rb
+++ b/lib/presently/display_view.rb
@@ -15,11 +15,11 @@ module Presently
 		# Initialize a new display view.
 		# @parameter id [String] The unique element identifier.
 		# @parameter data [Hash] The element data attributes.
-		# @parameter controller [PresentationController | Nil] The shared presentation controller.
-		def initialize(id = Live::Element.unique_id, data = {}, controller: nil)
+		# @parameter controller [PresentationController] The shared presentation controller.
+		def initialize(id, data, controller:)
 			super(id, data)
 			@controller = controller
-			@slide_renderer = SlideRenderer.new(css_class: "slide current", templates: controller&.templates)
+			@slide_renderer = SlideRenderer.new(css_class: "slide current", templates: controller.templates)
 		end
 		
 		# Bind this view to a page and register as a listener.

--- a/lib/presently/home_view.rb
+++ b/lib/presently/home_view.rb
@@ -1,0 +1,65 @@
+# frozen_string_literal: true
+
+# Released under the MIT License.
+# Copyright, 2026, by Samuel Williams.
+
+require "live"
+
+module Presently
+	# The home view which links to each presentation interface.
+	class HomeView < Live::View
+		INTERFACES = [
+			{
+				href: "/display",
+				title: "Audience Display",
+				description: "Show the synchronized presentation full-screen for the audience.",
+			},
+			{
+				href: "/presenter",
+				title: "Presenter Console",
+				description: "Control the presentation with speaker notes, timing, and slide previews.",
+			},
+			{
+				href: "/record",
+				title: "Narration Recorder",
+				description: "Record, review, and save narration for each slide.",
+			},
+			{
+				href: "/playback",
+				title: "Narrated Playback",
+				description: "Review the complete presentation with its recorded narration.",
+			},
+		].map(&:freeze).freeze
+		
+		# Initialize the home view.
+		# @parameter id [String] The unique element identifier.
+		# @parameter data [Hash] The element data attributes.
+		# @parameter controller [PresentationController | Nil] The shared presentation controller.
+		def initialize(id = Live::Element.unique_id, data = {}, controller: nil)
+			super(id, data)
+		end
+		
+		# Render links to the available presentation interfaces.
+		# @parameter builder [XRB::Builder] The HTML builder.
+		def render(builder)
+			builder.tag(:main, class: "home") do
+				builder.tag(:div, class: "home-heading") do
+					builder.tag(:p, class: "home-kicker"){builder.text("Presently")}
+					builder.tag(:h1){builder.text("Presentation interfaces")}
+					builder.tag(:p, class: "home-introduction") do
+						builder.text("Choose an interface to present, control, record, or review your presentation.")
+					end
+				end
+				
+				builder.tag(:nav, class: "home-interfaces", "aria-label": "Presentation interfaces") do
+					INTERFACES.each do |interface|
+						builder.tag(:a, class: "home-interface", href: interface[:href]) do
+							builder.tag(:strong){builder.text(interface[:title])}
+							builder.tag(:span){builder.text(interface[:description])}
+						end
+					end
+				end
+			end
+		end
+	end
+end

--- a/lib/presently/home_view.rb
+++ b/lib/presently/home_view.rb
@@ -34,8 +34,8 @@ module Presently
 		# Initialize the home view.
 		# @parameter id [String] The unique element identifier.
 		# @parameter data [Hash] The element data attributes.
-		# @parameter controller [PresentationController | Nil] The shared presentation controller.
-		def initialize(id = Live::Element.unique_id, data = {}, controller: nil)
+		# @parameter controller [PresentationController] The shared presentation controller.
+		def initialize(id, data, controller:)
 			super(id, data)
 		end
 		

--- a/lib/presently/presenter_view.rb
+++ b/lib/presently/presenter_view.rb
@@ -16,12 +16,12 @@ module Presently
 		# Initialize a new presenter view.
 		# @parameter id [String] The unique element identifier.
 		# @parameter data [Hash] The element data attributes.
-		# @parameter controller [PresentationController | Nil] The shared presentation controller.
-		def initialize(id = Live::Element.unique_id, data = {}, controller: nil)
+		# @parameter controller [PresentationController] The shared presentation controller.
+		def initialize(id, data, controller:)
 			super(id, data)
 			@controller = controller
 			@clock_task = nil
-			@preview_renderer = SlideRenderer.new(css_class: "slide preview-slide", templates: controller&.templates)
+			@preview_renderer = SlideRenderer.new(css_class: "slide preview-slide", templates: controller.templates)
 		end
 		
 		# Bind this view to a page and start the timing update loop.

--- a/lib/presently/recording_view.rb
+++ b/lib/presently/recording_view.rb
@@ -18,11 +18,11 @@ module Presently
 		# Initialize a recording view.
 		# @parameter id [String] The unique element identifier.
 		# @parameter data [Hash] The element data attributes.
-		# @parameter controller [PresentationController | Nil] The shared presentation controller.
-		def initialize(id = Live::Element.unique_id, data = {}, controller: nil)
+		# @parameter controller [PresentationController] The shared presentation controller.
+		def initialize(id, data, controller:)
 			super(id, data)
 			@controller = controller
-			@slide_renderer = SlideRenderer.new(css_class: "slide recording-slide", templates: controller&.templates)
+			@slide_renderer = SlideRenderer.new(css_class: "slide recording-slide", templates: controller.templates)
 		end
 		
 		# Bind this view to a page and register for slide changes.

--- a/presently.gemspec
+++ b/presently.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |spec|
 	
 	spec.required_ruby_version = ">= 3.3"
 	
-	spec.add_dependency "lively", "~> 0.20"
+	spec.add_dependency "lively", "~> 0.21"
 	spec.add_dependency "markly", "~> 0.16"
 	spec.add_dependency "async-webdriver", "~> 0.12"
 	spec.add_dependency "protocol-media-registry", "~> 0.0"

--- a/presently.gemspec
+++ b/presently.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |spec|
 	
 	spec.required_ruby_version = ">= 3.3"
 	
-	spec.add_dependency "lively", "~> 0.21"
+	spec.add_dependency "lively", "~> 0.22"
 	spec.add_dependency "markly", "~> 0.16"
 	spec.add_dependency "async-webdriver", "~> 0.12"
 	spec.add_dependency "protocol-media-registry", "~> 0.0"

--- a/public/_static/index.css
+++ b/public/_static/index.css
@@ -172,6 +172,104 @@ pre > syntax-code {
 	transition: opacity 0.15s ease-in;
 }
 
+/* ========================
+   HOME
+   ======================== */
+
+.home {
+	width: 100vw;
+	height: 100vh;
+	overflow: auto;
+	display: flex;
+	flex-direction: column;
+	justify-content: center;
+	padding: clamp(2rem, 8vw, 8rem);
+	background:
+		radial-gradient(circle at top left, color-mix(in srgb, var(--accent) 20%, transparent), transparent 35rem),
+		var(--slide-bg);
+}
+
+.home-heading,
+.home-interfaces {
+	width: min(72rem, 100%);
+	margin-inline: auto;
+}
+
+.home-heading {
+	margin-bottom: 3rem;
+}
+
+.home-kicker {
+	margin: 0 0 0.75rem;
+	color: var(--accent-light);
+	font-size: 0.9rem;
+	font-weight: 700;
+	letter-spacing: 0.12em;
+	text-transform: uppercase;
+}
+
+.home-heading h1 {
+	margin: 0;
+	font-size: clamp(2.5rem, 6vw, 5rem);
+	line-height: 1;
+}
+
+.home-introduction {
+	max-width: 48rem;
+	margin: 1.25rem 0 0;
+	font-size: clamp(1.1rem, 2vw, 1.4rem);
+	line-height: 1.5;
+	opacity: 0.72;
+}
+
+.home-interfaces {
+	display: grid;
+	grid-template-columns: repeat(2, minmax(0, 1fr));
+	gap: 1rem;
+}
+
+.home-interface {
+	display: flex;
+	min-height: 10rem;
+	flex-direction: column;
+	justify-content: space-between;
+	gap: 1.5rem;
+	padding: 1.75rem;
+	border: 1px solid rgba(255, 255, 255, 0.12);
+	border-radius: 0.75rem;
+	background: color-mix(in srgb, var(--surface) 82%, transparent);
+	color: inherit;
+	text-decoration: none;
+	transition: border-color 150ms ease, transform 150ms ease, background 150ms ease;
+}
+
+.home-interface:hover,
+.home-interface:focus-visible {
+	border-color: var(--accent-light);
+	background: color-mix(in srgb, var(--surface-light) 85%, transparent);
+	transform: translateY(-0.2rem);
+	outline: none;
+}
+
+.home-interface strong {
+	font-size: 1.4rem;
+}
+
+.home-interface span {
+	line-height: 1.5;
+	opacity: 0.7;
+}
+
+@media (max-width: 48rem) {
+	.home {
+		justify-content: flex-start;
+	}
+	
+	.home-interfaces {
+		grid-template-columns: 1fr;
+	}
+}
+
 /* Statement template */
 .statement-template {
 	text-align: center;

--- a/readme.md
+++ b/readme.md
@@ -24,6 +24,8 @@ A web-based presentation tool built with [Lively](https://github.com/socketry/li
 
 Please see the [project documentation](https://socketry.github.io/presently/) for more details.
 
+After starting Presently, open `http://localhost:9292/` to choose between the audience display, presenter console, narration recorder, and narrated playback interfaces.
+
   - [Getting Started](https://socketry.github.io/presently/guides/getting-started/index) - This guide explains how to use `presently` to create and deliver web-based presentations using Markdown slides.
 
   - [Animating Slides](https://socketry.github.io/presently/guides/animating-slides/index) - This guide explains how to animate content within slides using the slide scripting system.

--- a/test/presently/application.rb
+++ b/test/presently/application.rb
@@ -36,6 +36,24 @@ describe Presently::Application do
 		Protocol::HTTP::Request[method, path, headers, Protocol::HTTP::Body::Buffered.wrap(body)]
 	end
 	
+	it "serves a home page linking to each presentation interface" do
+		response = application.call(request("GET", "/"))
+		html = response.read
+		
+		expect(response.status).to be == 200
+		expect(html).to be(:include?, 'href="/display"')
+		expect(html).to be(:include?, 'href="/presenter"')
+		expect(html).to be(:include?, 'href="/record"')
+		expect(html).to be(:include?, 'href="/playback"')
+	end
+	
+	it "serves the audience display separately from the home page" do
+		response = application.call(request("GET", "/display"))
+		
+		expect(response.status).to be == 200
+		expect(response.read).to be(:include?, "Example slide")
+	end
+	
 	it "serves the recording interface separately from the presenter" do
 		response = application.call(request("GET", "/record"))
 		
@@ -59,7 +77,7 @@ describe Presently::Application do
 	it "includes presentation stylesheets in live pages" do
 		File.write(File.join(slides_root, "style.css"), ".slide { color: blue; }\n")
 		
-		response = application.call(request("GET", "/"))
+		response = application.call(request("GET", "/display"))
 		
 		expect(response.read).to be(:include?, 'href="/_slides/style.css"')
 	end

--- a/test/presently/application.rb
+++ b/test/presently/application.rb
@@ -48,7 +48,7 @@ describe Presently::Application do
 	end
 	
 	it "exposes page construction as a public customization interface" do
-		view = application.make_view(Presently::DisplayView)
+		view = application.resolver.root(Presently::DisplayView)
 		page = application.make_page(view)
 		
 		expect(page).to be_a(Presently::Page)

--- a/test/presently/application.rb
+++ b/test/presently/application.rb
@@ -47,6 +47,13 @@ describe Presently::Application do
 		expect(html).to be(:include?, 'href="/playback"')
 	end
 	
+	it "exposes page construction as a public customization interface" do
+		view = application.make_view(Presently::DisplayView)
+		page = application.make_page(view)
+		
+		expect(page).to be_a(Presently::Page)
+	end
+	
 	it "serves the audience display separately from the home page" do
 		response = application.call(request("GET", "/display"))
 		

--- a/test/presently/recording_view.rb
+++ b/test/presently/recording_view.rb
@@ -26,7 +26,7 @@ describe Presently::RecordingView do
 	end
 	
 	it "renders a dedicated recording interface" do
-		html = Presently::Page.new(body: view).call
+		html = Presently::Page.new(body: view).to_html
 		
 		expect(html).to be(:include?, "Example slide")
 		expect(html).to be(:include?, "Narrate this slide.")

--- a/test/presently/recording_view.rb
+++ b/test/presently/recording_view.rb
@@ -15,7 +15,7 @@ describe Presently::RecordingView do
 	let(:path) {File.join(dir, "010-example.md")}
 	let(:presentation) {Presently::Presentation.load(dir)}
 	let(:controller) {Presently::PresentationController.new(presentation)}
-	let(:view) {subject.new(controller: controller)}
+	let(:view) {subject.root(controller: controller)}
 	
 	before do
 		File.write(path, "---\nmarker: Example\n---\nExample slide\n\n---\nNarrate this slide.\n")


### PR DESCRIPTION
## Summary

- add a responsive launcher at `/` for the audience display, presenter console, narration recorder, and narrated playback
- move the synchronized audience-facing presentation to `/display`
- update routing tests and user documentation for the new entry points
- update to Lively 0.22 and construct root views through `resolver.root`
- use unary route handlers, explicit query parsing, and parameterless `Page#call`
- adopt Live 0.19 explicit `id, data` view constructors

## Testing

- `bundle exec bake test` (161 tests, 231 assertions)
- `bundle exec rubocop` (73 files, no offenses)
- `bundle exec bake decode:index:coverage lib` (167/167 public definitions documented)
- verified Lively 0.22.0, Live 0.19.0, and protocol-url 0.19.0 through Bundler
- visually checked the launcher in headless Chrome at 1440×1000
- `git diff --check`