### PR TITLE
Emit scoped slide rendering events

### DIFF
--- a/lib/presently/display_view.rb
+++ b/lib/presently/display_view.rb
@@ -3,7 +3,7 @@
 # Released under the MIT License.
 # Copyright, 2026, by Samuel Williams.
 
-require "live"
+require_relative "slide_view"
 require_relative "slide_renderer"
 
 module Presently
@@ -11,7 +11,7 @@ module Presently
 	#
 	# Connects to the {PresentationController} as a listener and updates
 	# whenever the slide changes. Pushes the current state on WebSocket reconnect.
-	class DisplayView < Live::View
+	class DisplayView < SlideView
 		# Initialize a new display view.
 		# @parameter id [String] The unique element identifier.
 		# @parameter data [Hash] The element data attributes.
@@ -28,7 +28,7 @@ module Presently
 		def bind(page)
 			super
 			@controller.add_listener(self)
-			self.update!
+			self.render_slide!(transition: @controller.current_slide&.transition)
 		end
 		
 		# Close this view and unregister as a listener.
@@ -39,7 +39,7 @@ module Presently
 		
 		# Called by the controller when the slide changes.
 		def slide_changed!
-			self.update!
+			self.render_slide!(transition: @controller.current_slide&.transition)
 		end
 		
 		# Handle an event from the client.

--- a/lib/presently/presenter_view.rb
+++ b/lib/presently/presenter_view.rb
@@ -3,7 +3,7 @@
 # Released under the MIT License.
 # Copyright, 2026, by Samuel Williams.
 
-require "live"
+require_relative "slide_view"
 require_relative "slide_renderer"
 require_relative "editor"
 
@@ -12,7 +12,7 @@ module Presently
 	#
 	# Shows the current slide, next slide preview, presenter notes, timing controls,
 	# and pacing indicators. Updates the timing display every second via a background task.
-	class PresenterView < Live::View
+	class PresenterView < SlideView
 		# Initialize a new presenter view.
 		# @parameter id [String] The unique element identifier.
 		# @parameter data [Hash] The element data attributes.
@@ -48,7 +48,7 @@ module Presently
 		
 		# Called by the controller when the slide changes.
 		def slide_changed!
-			self.update!
+			self.render_slide!
 		end
 		
 		# Push an update to just the timing section.

--- a/lib/presently/recording_view.rb
+++ b/lib/presently/recording_view.rb
@@ -3,9 +3,8 @@
 # Released under the MIT License.
 # Copyright, 2026, by Samuel Williams.
 
-require "live"
-
 require_relative "editor"
+require_relative "slide_view"
 require_relative "slide_renderer"
 
 module Presently
@@ -14,7 +13,7 @@ module Presently
 	# Recording is intentionally separate from {PresenterView}: presenting is a
 	# live performance interface, while recording is an authoring workflow with
 	# retakes, playback, and explicit saving.
-	class RecordingView < Live::View
+	class RecordingView < SlideView
 		# Initialize a recording view.
 		# @parameter id [String] The unique element identifier.
 		# @parameter data [Hash] The element data attributes.
@@ -40,7 +39,7 @@ module Presently
 		
 		# Update the recording interface when the current slide changes.
 		def slide_changed!
-			self.update!
+			self.render_slide!
 		end
 		
 		# Handle navigation events from the recording interface.

--- a/lib/presently/slide_view.rb
+++ b/lib/presently/slide_view.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+# Released under the MIT License.
+# Copyright, 2026, by Samuel Williams.
+
+require "live"
+
+module Presently
+	# A live view containing presentation slide content.
+	class SlideView < Live::View
+		# Ask the client to render the current slide view.
+		# @parameter transition [String | Nil] The transition to apply while rendering.
+		def render_slide!(transition: nil)
+			dispatch_event("##{@id}", "presently:slide:render",
+				bubbles: true,
+				detail: {
+					html: self.to_html.to_s,
+					transition: transition,
+				}
+			)
+		end
+	end
+end

--- a/public/application.js
+++ b/public/application.js
@@ -5,20 +5,16 @@ import { applyCodeFocus } from './code-focus.js';
 
 import './recorder.js';
 
-const live = Live.start();
+const SLIDE_RENDER_EVENT = 'presently:slide:render';
+const SLIDE_CHANGE_EVENT = 'presently:slide:change';
+
+let live = null;
 
 async function highlightAndApplyCodeFocus() {
 	await Syntax.highlight();
 	await applyCodeFocus();
 }
 
-// Highlight code blocks on initial load and apply focus once rendering finishes:
-await highlightAndApplyCodeFocus();
-
-
-// Run the script for a single slide element.
-// Wrapped in try/catch so syntax errors don't crash the presentation.
-// Passes a tracked setTimeout so pending timeouts can be cancelled on slide change.
 // Run scripts for all slide elements currently in the DOM.
 // Cancels any pending timeouts from the previous slide's scripts first.
 function runSlideScripts() {
@@ -30,51 +26,54 @@ function runSlideScripts() {
 	});
 }
 
-
-// Detect the transition type from the incoming HTML before morphdom applies it.
-function detectTransition(html) {
-	const match = html.match(/data-transition="([^"]+)"/);
-	return match ? match[1] : null;
-}
-
 // Track the active view transition so we can skip overlapping ones.
 let activeTransition = null;
 
 // Track Slide instances from the current scripts so we can cancel their timeouts on slide change.
 let currentSlides = [];
 
-// Wrap Live's update method to support view transitions.
-const originalUpdate = live.update.bind(live);
-live.update = function(id, html, options) {
-	// Only apply transitions on the display view, not the presenter:
-	const transition = document.querySelector('.display') ? detectTransition(html) : null;
+function dispatchSlideChange(view) {
+	view.dispatchEvent(new CustomEvent(SLIDE_CHANGE_EVENT, {bubbles: true}));
+}
+
+function renderSlide(event) {
+	const view = event.target.closest?.('live-view');
+	if (!view) return;
+
+	const {html, transition} = event.detail;
+	const render = () => {
+		live.update(view.id, html);
+		runSlideScripts();
+	};
 	
 	if (transition && document.startViewTransition && !activeTransition) {
 		document.documentElement.dataset.transition = transition;
 
-		activeTransition = document.startViewTransition(() => {
-			originalUpdate(id, html, options);
-			runSlideScripts();
-		});
+		const viewTransition = document.startViewTransition(render);
+		activeTransition = viewTransition;
 
-		activeTransition.finished.finally(() => {
+		const complete = () => {
 			delete document.documentElement.dataset.transition;
 			activeTransition = null;
-			highlightAndApplyCodeFocus();
-		});
-	} else {
-		originalUpdate(id, html, options);
-		runSlideScripts();
-		highlightAndApplyCodeFocus();
-	}
-};
+			dispatchSlideChange(view);
+		};
 
-// Re-highlight and apply focus after non-update DOM mutations (e.g. replace):
-const observer = new MutationObserver(() => {
-	if (activeTransition) return;
+		viewTransition.finished.then(complete, complete);
+	} else {
+		render();
+		dispatchSlideChange(view);
+	}
+}
+
+document.addEventListener(SLIDE_RENDER_EVENT, renderSlide);
+document.addEventListener(SLIDE_CHANGE_EVENT, () => {
 	highlightAndApplyCodeFocus();
 });
-observer.observe(document.body, { childList: true, subtree: true });
+
+// Initialize the server-rendered slide before connecting for subsequent updates:
+await highlightAndApplyCodeFocus();
+
+live = Live.start();
 
 // Initial script application:
 runSlideScripts();

--- a/test/presently/slide_view.rb
+++ b/test/presently/slide_view.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+# Released under the MIT License.
+# Copyright, 2026, by Samuel Williams.
+
+require "presently/slide_view"
+
+describe Presently::SlideView do
+	let(:view) {subject.new("example", {})}
+	let(:updates) {[]}
+	let(:page) do
+		updates = self.updates
+		
+		Object.new.tap do |page|
+			page.define_singleton_method(:enqueue) do |update|
+				updates << update
+			end
+		end
+	end
+	
+	with "#render_slide!" do
+		it "dispatches a client-side slide render event" do
+			view.bind(page)
+			view.render_slide!(transition: "fade")
+			
+			method, selector, event, options = updates.last
+			
+			expect(method).to be == :dispatchEvent
+			expect(selector).to be == "#example"
+			expect(event).to be == "presently:slide:render"
+			expect(options[:bubbles]).to be == true
+			expect(options.dig(:detail, :html)).to be(:include?, '<live-view id="example"')
+			expect(options.dig(:detail, :transition)).to be == "fade"
+		end
+	end
+end


### PR DESCRIPTION
Replace the Live.update monkey patch and broad MutationObserver with a Presently-owned slide rendering lifecycle.

Slide views now emit presently:slide:render with the rendered HTML and optional transition. The client performs the update, runs slide scripts, and emits presently:slide:change after the change completes. Initial server-rendered content is initialized before Live connects.

Validation:
- Full suite: 162 tests, 237 assertions.
- Ruby syntax, JavaScript syntax, RuboCop, diff checks, and Decode documentation coverage pass.