### PR TITLE
Update Syntax to 0.6.2

### DIFF
--- a/components/presently/package.json
+++ b/components/presently/package.json
@@ -13,6 +13,6 @@
 		"test": "node --test test/*.js"
 	},
 	"dependencies": {
-		"@socketry/syntax": "^0.6.1"
+		"@socketry/syntax": "^0.6.2"
 	}
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,8 +11,9 @@
 		},
 		"components/presently": {
 			"name": "@socketry/presently",
+			"license": "MIT",
 			"dependencies": {
-				"@socketry/syntax": "^0.6.1"
+				"@socketry/syntax": "^0.6.2"
 			}
 		},
 		"node_modules/@socketry/presently": {
@@ -20,9 +21,9 @@
 			"link": true
 		},
 		"node_modules/@socketry/syntax": {
-			"version": "0.6.1",
-			"resolved": "https://registry.npmjs.org/@socketry/syntax/-/syntax-0.6.1.tgz",
-			"integrity": "sha512-PFhYoPxKxB9YJorfcOx92++tKpiET8KpuxHbo9VbcAj9bINeVYCkAsMNgbswnxf9whLNZsAj5FCqt0I8oGAe2g==",
+			"version": "0.6.2",
+			"resolved": "https://registry.npmjs.org/@socketry/syntax/-/syntax-0.6.2.tgz",
+			"integrity": "sha512-K+CnV/L4p39/LCR9fnycYahz8Nbo4MjRCiyaR4uIqE7zvwIQ+BkDsJkM1skz1oDvH8iIZrkVVDC01dpQ1a2VeA==",
 			"license": "MIT"
 		}
 	}

--- a/public/_components/.manifest.json
+++ b/public/_components/.manifest.json
@@ -18,7 +18,7 @@
       }
     },
     "@socketry/syntax": {
-      "version": "0.6.1",
+      "version": "0.6.2",
       "source": ".",
       "files": {
         "Syntax.js": "54303c31cc89c7e0c0c7e4aab677496c651eae22d1130f154cc065f78639c65f",
@@ -59,7 +59,7 @@
         "Syntax/Language/plain.js": "fad239eb2993f89b5948aefbbd38383830a156b7f4e67dc8f848f9a57f6b099b",
         "Syntax/Language/protobuf.js": "fef37118f90f4073004a3b29fb65f36c3d257371203089b9fbcccda1965cf62b",
         "Syntax/Language/python.js": "1043eafaa52e19bf2959a53952ab083dc1c6dd57263824a903cb4b0f47f7f7f5",
-        "Syntax/Language/ruby.js": "9188b7fad5a3a3ee2e9315c96d88ef6790c5e288b5be88c08d5d86c240340817",
+        "Syntax/Language/ruby.js": "5aaa67f804944987a2da53c99b4b4a9550392f7d9bad806cfdf62f07f6790e9e",
         "Syntax/Language/scala.js": "7cad17b50f51f63217a3b009fbd4f873c928e567e1a27170784dc4d11796d003",
         "Syntax/Language/smalltalk.js": "033dd1bfa9f9546a8bfb52a30fd830fdbcfa6f503e3c19e73104447627a22752",
         "Syntax/Language/sql.js": "e78508fad5281539fc332873b4485c6a695ea5f01c0f4f06b4698fc169b865fd",
@@ -72,7 +72,7 @@
         "Syntax/Match.js": "1e1f1b409af439c63ecc2818017039bdd2446ed7e60ed733b326001bc7826253",
         "Syntax/Rule.js": "7504ce7bfa1e0619910f8798d37adea79168cec99a5cadf7dbb3c27ce805037a",
         "license.md": "0e9cd91597ba8a5b11fe18ecfb38ed6b275450e07ca0ed85ed111725393e6c98",
-        "package.json": "d978ec9223c91eb5f47a9ba23e9332f92d2db88447e358e5c17d919071ae4826",
+        "package.json": "475169e000cb69bbfae762a73a95ccf229dc958cb035560c3fd04fc07769112b",
         "readme.md": "c5b3fead9196989000a3ab5f509b9d7d35b479e875b2bfd21e6700e0cea92f9f",
         "themes/base/apache.css": "8a261eabf17d57cfc34fa2f757dc5e707a4ec1920613d636eda2bc52027de5d9",
         "themes/base/applescript.css": "12c998dc887880897b2bbc10a890c2704c1728824ed329f4cadc23414226e90b",
@@ -117,5 +117,5 @@
       }
     }
   },
-  "digest": "ea64238dded9ab0ee179cf4be5a75dfee8ca556eafd66eb00bbd0811ed860acf"
+  "digest": "e33cb31256e3bdbb275db6b20506f38454da1ec7f4fe1352f47decbab640614c"
 }

--- a/public/_components/@socketry/syntax/Syntax/Language/ruby.js
+++ b/public/_components/@socketry/syntax/Syntax/Language/ruby.js
@@ -4,11 +4,15 @@ import {Match} from '../Match.js';
 
 const language = new Language('ruby');
 
-// Ruby-style function definitions and method calls (def foo, .bar)
-// Method names can end with ? or !
+// Ruby-style function definitions and method calls (def foo, .bar).
+// Predicate and bang methods are also unambiguous without a receiver or arguments.
 const rubyStyleFunction = {
-	pattern: /(?:def\s+|\.)([a-z_][a-z0-9_]*[?!]?)/i,
-	matches: Rule.extractMatches({type: 'function'})
+	pattern:
+		/(?:def\s+|\.)([a-z_][a-z0-9_]*[?!]?)|(^|[^\w.:])([a-z_][a-z0-9_]*[?!])(?!:)/i,
+	matches: Rule.extractMatches(
+		{index: 1, type: 'function'},
+		{index: 3, type: 'function'}
+	)
 };
 
 // Emulate negative lookbehind to avoid matching ::symbol (only match :symbol not ::symbol)

--- a/public/_components/@socketry/syntax/package.json
+++ b/public/_components/@socketry/syntax/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@socketry/syntax",
-	"version": "0.6.1",
+	"version": "0.6.2",
 	"description": "A modern, framework-agnostic syntax highlighter using Web Components",
 	"type": "module",
 	"main": "Syntax.js",


### PR DESCRIPTION
## Summary

- Update `@socketry/syntax` from `^0.6.1` to `^0.6.2`.
- Regenerate the Web Packages projection with the updated Ruby predicate and bang method highlighting.

## Testing

- `npm test`
- `bundle exec bake test`
- `bundle exec bake web:packages:check`