### PR TITLE
Fix slide render event selector

### DIFF
--- a/lib/presently/slide_view.rb
+++ b/lib/presently/slide_view.rb
@@ -11,7 +11,7 @@ module Presently
 		# Ask the client to render the current slide view.
 		# @parameter transition [String | Nil] The transition to apply while rendering.
 		def render_slide!(transition: nil)
-			dispatch_event("##{@id}", "presently:slide:render",
+			dispatch_event(self.selector, "presently:slide:render",
 				bubbles: true,
 				detail: {
 					html: self.to_html.to_s,

--- a/presently.gemspec
+++ b/presently.gemspec
@@ -27,6 +27,7 @@ Gem::Specification.new do |spec|
 	spec.required_ruby_version = ">= 3.3"
 	
 	spec.add_dependency "lively", "~> 0.22"
+	spec.add_dependency "live", "~> 0.21"
 	spec.add_dependency "markly", "~> 0.16"
 	spec.add_dependency "async-webdriver", "~> 0.12"
 	spec.add_dependency "protocol-media-registry", "~> 0.0"

--- a/releases.md
+++ b/releases.md
@@ -1,5 +1,9 @@
 # Releases
 
+## Unreleased
+
+  - Fix slide rendering events for generated view identifiers that begin with a digit.
+
 ## v0.17.1
 
   - Add slide-scoped resource cleanup with `Slide#defer`, `Slide#signal`, and idempotent `Slide#dispose`. Existing tracked timeouts now use the same disposal lifecycle.

--- a/test/presently/slide_view.rb
+++ b/test/presently/slide_view.rb
@@ -6,7 +6,7 @@
 require "presently/slide_view"
 
 describe Presently::SlideView do
-	let(:view) {subject.new("example", {})}
+	let(:view) {subject.new("2eef0b2c-fe65-4aba-ba90-0a6a83a6ce80", {})}
 	let(:updates) {[]}
 	let(:page) do
 		updates = self.updates
@@ -26,10 +26,10 @@ describe Presently::SlideView do
 			method, selector, event, options = updates.last
 			
 			expect(method).to be == :dispatchEvent
-			expect(selector).to be == "#example"
+			expect(selector).to be == '[id="2eef0b2c-fe65-4aba-ba90-0a6a83a6ce80"]'
 			expect(event).to be == "presently:slide:render"
 			expect(options[:bubbles]).to be == true
-			expect(options.dig(:detail, :html)).to be(:include?, '<live-view id="example"')
+			expect(options.dig(:detail, :html)).to be(:include?, '<live-view id="2eef0b2c-fe65-4aba-ba90-0a6a83a6ce80"')
 			expect(options.dig(:detail, :transition)).to be == "fade"
 		end
 	end


### PR DESCRIPTION
## Summary

Use the selector provided by `Live::Element#selector` when dispatching `presently:slide:render`. This supports generated UUID identifiers beginning with a digit, which are valid HTML IDs but cannot be interpolated directly into an unescaped CSS ID selector.

Require Live v0.21 or newer, where the selector abstraction was introduced, and add regression coverage using the UUID from the reported browser error.

## Validation

- 162 tests pass (237 assertions)
- RuboCop passes
- Documentation coverage remains 100%