### PR TITLE
Fix slide transition flicker

### DIFF
--- a/public/_static/index.css
+++ b/public/_static/index.css
@@ -513,29 +513,26 @@ live-view:has(.display) {
 
 /* Fade */
 html[data-transition="fade"]::view-transition-old(slide-container) {
-	animation: vt-fade-out 0.4s ease-in-out;
-}
-
-html[data-transition="fade"]::view-transition-new(slide-container) {
-	animation: vt-fade-in 0.4s ease-in-out;
+	animation: vt-fade-out 0.4s ease-in-out both;
+	z-index: 1;
 }
 
 /* Slide left */
 html[data-transition="slide-left"]::view-transition-old(slide-container) {
-	animation: vt-slide-out-left 0.4s ease-in-out;
+	animation: vt-slide-out-left 0.4s ease-in-out both;
 }
 
 html[data-transition="slide-left"]::view-transition-new(slide-container) {
-	animation: vt-slide-in-right 0.4s ease-in-out;
+	animation: vt-slide-in-right 0.4s ease-in-out both;
 }
 
 /* Slide right */
 html[data-transition="slide-right"]::view-transition-old(slide-container) {
-	animation: vt-slide-out-right 0.4s ease-in-out;
+	animation: vt-slide-out-right 0.4s ease-in-out both;
 }
 
 html[data-transition="slide-right"]::view-transition-new(slide-container) {
-	animation: vt-slide-in-left 0.4s ease-in-out;
+	animation: vt-slide-in-left 0.4s ease-in-out both;
 }
 
 /* ========================

--- a/releases.md
+++ b/releases.md
@@ -4,6 +4,7 @@
 
   - Render slides on a responsive 16:9 canvas across the display, presenter, recording, playback, and export interfaces.
   - Center diagram content by default, add optional diagram titles, and make free-form absolute positioning explicit with `.diagram-freeform`.
+  - Prevent slide backgrounds and content from flickering during view transitions.
 
 ## v0.17.2
 


### PR DESCRIPTION
Fix fade transitions by keeping the incoming slide opaque beneath the outgoing snapshot. The outgoing slide now fades away from above, avoiding the dark compositing dip without additive blending.

Retain final animation keyframes until transition snapshots are removed, preventing an end-frame flash for fade and directional transitions.

Validated with the Ruby and JavaScript test suites, RuboCop, and the web package projection check.