### PR TITLE
Truncate long slide paths in presenter controls

### DIFF
--- a/lib/presently/export.rb
+++ b/lib/presently/export.rb
@@ -117,7 +117,7 @@ module Presently
 						builder.text("Elapsed: #{format_duration(elapsed)}")
 					end
 					builder.tag(:span, class: "export-duration") do
-						builder.text("Slide: #{format_duration(slide.duration)}")
+						builder.text("Duration: #{format_duration(slide.duration)}")
 					end
 				end
 				

--- a/lib/presently/presenter_view.rb
+++ b/lib/presently/presenter_view.rb
@@ -199,13 +199,13 @@ module Presently
 					end
 					
 					builder.tag(:span, class: "slide-info") do
-						builder.text("Slide #{@controller.current_index + 1} of #{@controller.slide_count}")
+						builder.tag(:span, class: "slide-position") do
+							builder.text("Slide #{@controller.current_index + 1} of #{@controller.slide_count}")
+						end
 						
 						if slide
 							builder.text(" · ")
-							builder.tag(:code, class: "slide-path") do
-								builder.text(slide.path)
-							end
+							render_slide_path(builder, slide.path)
 							
 							if editor_url = editor_url_for(slide.source_path)
 								builder.tag(:a, href: editor_url, class: "edit-link") do

--- a/lib/presently/presenter_view.rb
+++ b/lib/presently/presenter_view.rb
@@ -151,7 +151,7 @@ module Presently
 					
 					if slide
 						builder.tag(:span, class: "slide-duration") do
-							builder.text("Slide: #{format_duration(slide.duration)}")
+							builder.text("Duration: #{format_duration(slide.duration)}")
 						end
 					end
 					

--- a/lib/presently/presenter_view.rb
+++ b/lib/presently/presenter_view.rb
@@ -231,7 +231,7 @@ module Presently
 					unless markers.empty?
 						builder.tag(:select,
 							class: "jump-to",
-							data: {live_id: @id}
+							"data-live-id": @id
 						) do
 							builder.tag(:option, value: "", disabled: true, selected: true) do
 								builder.text("Jump to…")

--- a/lib/presently/presenter_view.rb
+++ b/lib/presently/presenter_view.rb
@@ -198,6 +198,12 @@ module Presently
 						builder.text("← Previous")
 					end
 					
+					builder.tag(:button,
+						onClick: forward_event(action: "next")
+					) do
+						builder.text("Next →")
+					end
+					
 					builder.tag(:span, class: "slide-info") do
 						builder.tag(:span, class: "slide-position") do
 							builder.text("Slide #{@controller.current_index + 1} of #{@controller.slide_count}")
@@ -212,12 +218,6 @@ module Presently
 								end
 							end
 						end
-					end
-					
-					builder.tag(:button,
-						onClick: forward_event(action: "next")
-					) do
-						builder.text("Next →")
 					end
 					
 					# Jump-to dropdown for marked slides

--- a/lib/presently/presenter_view.rb
+++ b/lib/presently/presenter_view.rb
@@ -204,7 +204,6 @@ module Presently
 						end
 						
 						if slide
-							builder.text(" · ")
 							render_slide_path(builder, slide.path)
 							
 							if editor_url = editor_url_for(slide.source_path)

--- a/lib/presently/presenter_view.rb
+++ b/lib/presently/presenter_view.rb
@@ -110,7 +110,7 @@ module Presently
 				else "on-time"
 				end
 				
-				builder.tag(:div, class: "timing-info #{pacing_class}") do
+				builder.tag(:div, class: "toolbar timing-info #{pacing_class}") do
 					builder.tag(:button,
 						class: "pause-button",
 						onClick: forward_event(action: "pause")
@@ -191,7 +191,7 @@ module Presently
 			
 			builder.tag(:div, class: "presenter") do
 				# Controls bar
-				builder.tag(:div, class: "controls") do
+				builder.tag(:div, class: "toolbar controls") do
 					builder.tag(:button,
 						onClick: forward_event(action: "previous")
 					) do

--- a/lib/presently/recording_view.rb
+++ b/lib/presently/recording_view.rb
@@ -124,7 +124,7 @@ module Presently
 		# @parameter builder [XRB::Builder] The HTML builder.
 		# @parameter slide [Slide] The current slide.
 		def render_navigation(builder, slide)
-			builder.tag(:div, class: "controls recording-navigation") do
+			builder.tag(:div, class: "toolbar controls recording-navigation") do
 				builder.tag(:button, onClick: forward_event(action: "previous")){builder.text("← Previous")}
 				
 				builder.tag(:span, class: "slide-info") do

--- a/lib/presently/recording_view.rb
+++ b/lib/presently/recording_view.rb
@@ -131,7 +131,6 @@ module Presently
 					builder.tag(:span, class: "slide-position") do
 						builder.text("Slide #{@controller.current_index + 1} of #{@controller.slide_count}")
 					end
-					builder.text(" · ")
 					render_slide_path(builder, slide.path)
 					
 					if editor_url = editor_url_for(slide.source_path)

--- a/lib/presently/recording_view.rb
+++ b/lib/presently/recording_view.rb
@@ -126,6 +126,7 @@ module Presently
 		def render_navigation(builder, slide)
 			builder.tag(:div, class: "toolbar controls recording-navigation") do
 				builder.tag(:button, onClick: forward_event(action: "previous")){builder.text("← Previous")}
+				builder.tag(:button, onClick: forward_event(action: "next")){builder.text("Next →")}
 				
 				builder.tag(:span, class: "slide-info") do
 					builder.tag(:span, class: "slide-position") do
@@ -137,8 +138,6 @@ module Presently
 						builder.tag(:a, href: editor_url, class: "edit-link"){builder.text("✎")}
 					end
 				end
-				
-				builder.tag(:button, onClick: forward_event(action: "next")){builder.text("Next →")}
 				
 				markers = @controller.slides.each_with_index.filter_map do |candidate, index|
 					[index, candidate.marker] if candidate.marker

--- a/lib/presently/recording_view.rb
+++ b/lib/presently/recording_view.rb
@@ -128,8 +128,11 @@ module Presently
 				builder.tag(:button, onClick: forward_event(action: "previous")){builder.text("← Previous")}
 				
 				builder.tag(:span, class: "slide-info") do
-					builder.text("Slide #{@controller.current_index + 1} of #{@controller.slide_count} · ")
-					builder.tag(:code, class: "slide-path"){builder.text(slide.path)}
+					builder.tag(:span, class: "slide-position") do
+						builder.text("Slide #{@controller.current_index + 1} of #{@controller.slide_count}")
+					end
+					builder.text(" · ")
+					render_slide_path(builder, slide.path)
 					
 					if editor_url = editor_url_for(slide.source_path)
 						builder.tag(:a, href: editor_url, class: "edit-link"){builder.text("✎")}

--- a/lib/presently/slide_view.rb
+++ b/lib/presently/slide_view.rb
@@ -8,6 +8,26 @@ require "live"
 module Presently
 	# A live view containing presentation slide content.
 	class SlideView < Live::View
+		# Render a presentation-relative slide path which can truncate its directory.
+		# @parameter builder [XRB::Builder] The HTML builder.
+		# @parameter path [String] The presentation-relative slide path.
+		def render_slide_path(builder, path)
+			directory = File.dirname(path)
+			filename = File.basename(path)
+			
+			builder.tag(:code, class: "slide-path", title: path) do
+				unless directory == "."
+					builder.tag(:span, class: "slide-path-directory") do
+						builder.text(directory)
+					end
+				end
+				
+				builder.tag(:span, class: "slide-path-filename") do
+					builder.text(directory == "." ? filename : "/#{filename}")
+				end
+			end
+		end
+		
 		# Ask the client to render the current slide view.
 		# @parameter transition [String | Nil] The transition to apply while rendering.
 		def render_slide!(transition: nil)

--- a/public/_static/index.css
+++ b/public/_static/index.css
@@ -802,12 +802,15 @@ body.playback[data-controls="false"] .playback-start-screen {
 
 .controls .slide-info {
 	font-size: 1rem;
-	opacity: 0.8;
 	display: flex;
-	align-items: baseline;
+	align-items: stretch;
 	flex: 0 1 auto;
 	min-width: 0;
 	white-space: nowrap;
+	background: var(--surface-light);
+	border: 1px solid rgba(255,255,255,0.1);
+	border-radius: 6px;
+	overflow: hidden;
 }
 
 .controls .slide-position,
@@ -815,12 +818,23 @@ body.playback[data-controls="false"] .playback-start-screen {
 	flex: 0 0 auto;
 }
 
+.controls .slide-position {
+	display: flex;
+	align-items: center;
+	padding: 0.4rem 0.6rem;
+	font-size: 0.8rem;
+	opacity: 0.8;
+}
+
 .controls .slide-path {
 	font-size: 0.8rem;
 	opacity: 0.6;
 	display: inline-flex;
+	align-items: center;
 	flex: 0 1 auto;
 	min-width: 0;
+	padding: 0.4rem 0.6rem;
+	border-left: 1px solid rgba(255,255,255,0.1);
 }
 
 .controls .slide-path-directory,
@@ -839,7 +853,11 @@ body.playback[data-controls="false"] .playback-start-screen {
 }
 
 .controls .edit-link {
-	margin-left: 0.3rem;
+	display: flex;
+	align-items: center;
+	margin-left: 0;
+	padding: 0.4rem 0.5rem;
+	border-left: 1px solid rgba(255,255,255,0.1);
 	text-decoration: none;
 	opacity: 0.6;
 	transition: opacity 0.2s;

--- a/public/_static/index.css
+++ b/public/_static/index.css
@@ -806,15 +806,11 @@ body.playback[data-controls="false"] .playback-start-screen {
 	background: var(--accent);
 }
 
-.controls button.reload {
-	margin-left: auto;
-}
-
 .controls .slide-info {
 	font-size: 1rem;
 	display: flex;
 	align-items: stretch;
-	flex: 0 1 auto;
+	flex: 1 1 0;
 	min-width: 0;
 	white-space: nowrap;
 	overflow: hidden;

--- a/public/_static/index.css
+++ b/public/_static/index.css
@@ -759,6 +759,7 @@ body.playback[data-controls="false"] .playback-start-screen {
 .toolbar {
 	display: flex;
 	align-items: center;
+	gap: 1rem;
 }
 
 .toolbar > button,
@@ -771,7 +772,6 @@ body.playback[data-controls="false"] .playback-start-screen {
 }
 
 .controls {
-	gap: 1rem;
 	padding: 0.5rem 1rem;
 	background: var(--surface);
 	border-radius: 8px;
@@ -931,7 +931,6 @@ body.playback[data-controls="false"] .playback-start-screen {
 }
 
 .timing-info {
-	gap: 2rem;
 	font-size: 1rem;
 }
 

--- a/public/_static/index.css
+++ b/public/_static/index.css
@@ -803,11 +803,39 @@ body.playback[data-controls="false"] .playback-start-screen {
 .controls .slide-info {
 	font-size: 1rem;
 	opacity: 0.8;
+	display: flex;
+	align-items: baseline;
+	flex: 1 1 auto;
+	min-width: 0;
+	white-space: nowrap;
+}
+
+.controls .slide-position,
+.controls .edit-link {
+	flex: 0 0 auto;
 }
 
 .controls .slide-path {
 	font-size: 0.8rem;
 	opacity: 0.6;
+	display: inline-flex;
+	flex: 1 1 auto;
+	min-width: 0;
+}
+
+.controls .slide-path-directory,
+.controls .slide-path-filename {
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+}
+
+.controls .slide-path-directory {
+	flex: 1 1 0;
+}
+
+.controls .slide-path-filename {
+	flex: 0 1 auto;
 }
 
 .controls .edit-link {

--- a/public/_static/index.css
+++ b/public/_static/index.css
@@ -805,7 +805,7 @@ body.playback[data-controls="false"] .playback-start-screen {
 	opacity: 0.8;
 	display: flex;
 	align-items: baseline;
-	flex: 1 1 auto;
+	flex: 0 1 auto;
 	min-width: 0;
 	white-space: nowrap;
 }
@@ -819,7 +819,7 @@ body.playback[data-controls="false"] .playback-start-screen {
 	font-size: 0.8rem;
 	opacity: 0.6;
 	display: inline-flex;
-	flex: 1 1 auto;
+	flex: 0 1 auto;
 	min-width: 0;
 }
 

--- a/public/_static/index.css
+++ b/public/_static/index.css
@@ -13,6 +13,7 @@
 	--on-time: #2ed573;
 	--behind: #ff4757;
 	--ahead: #ffa502;
+	--control-height: 2.25rem;
 	--font-sans: "Inter", "Helvetica Neue", Arial, sans-serif;
 	--font-mono: "JetBrains Mono", "Fira Code", monospace;
 }
@@ -756,8 +757,6 @@ body.playback[data-controls="false"] .playback-start-screen {
 
 /* Controls */
 .controls {
-	--control-height: 2.25rem;
-	
 	display: flex;
 	align-items: center;
 	gap: 1rem;
@@ -766,16 +765,22 @@ body.playback[data-controls="false"] .playback-start-screen {
 	border-radius: 8px;
 }
 
+.controls > button,
+.controls > .jump-to,
+.controls > .slide-info,
+.timing-info > button {
+	height: var(--control-height);
+	background: var(--surface-light);
+	border: 1px solid rgba(255,255,255,0.1);
+	border-radius: 6px;
+}
+
 .controls button {
 	display: inline-flex;
 	align-items: center;
 	justify-content: center;
-	height: var(--control-height);
-	background: var(--surface-light);
 	color: var(--slide-text);
-	border: 1px solid rgba(255,255,255,0.1);
 	padding: 0 1rem;
-	border-radius: 6px;
 	cursor: pointer;
 	font-size: 0.9rem;
 	font-family: var(--font-sans);
@@ -787,12 +792,8 @@ body.playback[data-controls="false"] .playback-start-screen {
 }
 
 .controls .jump-to {
-	height: var(--control-height);
-	background: var(--surface-light);
 	color: var(--slide-text);
-	border: 1px solid rgba(255,255,255,0.1);
 	padding: 0 0.75rem;
-	border-radius: 6px;
 	font-size: 0.9rem;
 	font-family: var(--font-sans);
 	cursor: pointer;
@@ -808,16 +809,12 @@ body.playback[data-controls="false"] .playback-start-screen {
 }
 
 .controls .slide-info {
-	height: var(--control-height);
 	font-size: 1rem;
 	display: flex;
 	align-items: stretch;
 	flex: 0 1 auto;
 	min-width: 0;
 	white-space: nowrap;
-	background: var(--surface-light);
-	border: 1px solid rgba(255,255,255,0.1);
-	border-radius: 6px;
 	overflow: hidden;
 }
 
@@ -958,11 +955,8 @@ body.playback[data-controls="false"] .playback-start-screen {
 }
 
 .timing-info .pause-button {
-	background: var(--surface-light);
 	color: var(--slide-text);
-	border: 1px solid rgba(255,255,255,0.1);
 	padding: 0.3rem 0.75rem;
-	border-radius: 6px;
 	cursor: pointer;
 	font-size: 0.9rem;
 	font-family: var(--font-sans);

--- a/public/_static/index.css
+++ b/public/_static/index.css
@@ -821,8 +821,8 @@ body.playback[data-controls="false"] .playback-start-screen {
 .controls .slide-position {
 	display: flex;
 	align-items: center;
-	padding: 0.4rem 0.6rem;
-	font-size: 0.8rem;
+	padding: 0.5rem 0.75rem;
+	font-size: 0.9rem;
 	opacity: 0.8;
 }
 
@@ -833,7 +833,7 @@ body.playback[data-controls="false"] .playback-start-screen {
 	align-items: center;
 	flex: 0 1 auto;
 	min-width: 0;
-	padding: 0.4rem 0.6rem;
+	padding: 0.5rem 0.6rem;
 	border-left: 1px solid rgba(255,255,255,0.1);
 }
 
@@ -856,7 +856,7 @@ body.playback[data-controls="false"] .playback-start-screen {
 	display: flex;
 	align-items: center;
 	margin-left: 0;
-	padding: 0.4rem 0.5rem;
+	padding: 0.5rem;
 	border-left: 1px solid rgba(255,255,255,0.1);
 	text-decoration: none;
 	opacity: 0.6;

--- a/public/_static/index.css
+++ b/public/_static/index.css
@@ -756,23 +756,25 @@ body.playback[data-controls="false"] .playback-start-screen {
 }
 
 /* Controls */
-.controls {
+.toolbar {
 	display: flex;
 	align-items: center;
-	gap: 1rem;
-	padding: 0.5rem 1rem;
-	background: var(--surface);
-	border-radius: 8px;
 }
 
-.controls > button,
-.controls > .jump-to,
-.controls > .slide-info,
-.timing-info > button {
+.toolbar > button,
+.toolbar > select,
+.toolbar > .slide-info {
 	height: var(--control-height);
 	background: var(--surface-light);
 	border: 1px solid rgba(255,255,255,0.1);
 	border-radius: 6px;
+}
+
+.controls {
+	gap: 1rem;
+	padding: 0.5rem 1rem;
+	background: var(--surface);
+	border-radius: 8px;
 }
 
 .controls button {
@@ -929,9 +931,7 @@ body.playback[data-controls="false"] .playback-start-screen {
 }
 
 .timing-info {
-	display: flex;
 	gap: 2rem;
-	align-items: center;
 	font-size: 1rem;
 }
 

--- a/public/_static/index.css
+++ b/public/_static/index.css
@@ -756,6 +756,8 @@ body.playback[data-controls="false"] .playback-start-screen {
 
 /* Controls */
 .controls {
+	--control-height: 2.25rem;
+	
 	display: flex;
 	align-items: center;
 	gap: 1rem;
@@ -765,10 +767,14 @@ body.playback[data-controls="false"] .playback-start-screen {
 }
 
 .controls button {
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+	height: var(--control-height);
 	background: var(--surface-light);
 	color: var(--slide-text);
 	border: 1px solid rgba(255,255,255,0.1);
-	padding: 0.5rem 1rem;
+	padding: 0 1rem;
 	border-radius: 6px;
 	cursor: pointer;
 	font-size: 0.9rem;
@@ -781,10 +787,11 @@ body.playback[data-controls="false"] .playback-start-screen {
 }
 
 .controls .jump-to {
+	height: var(--control-height);
 	background: var(--surface-light);
 	color: var(--slide-text);
 	border: 1px solid rgba(255,255,255,0.1);
-	padding: 0.5rem 0.75rem;
+	padding: 0 0.75rem;
 	border-radius: 6px;
 	font-size: 0.9rem;
 	font-family: var(--font-sans);
@@ -801,6 +808,7 @@ body.playback[data-controls="false"] .playback-start-screen {
 }
 
 .controls .slide-info {
+	height: var(--control-height);
 	font-size: 1rem;
 	display: flex;
 	align-items: stretch;
@@ -821,7 +829,7 @@ body.playback[data-controls="false"] .playback-start-screen {
 .controls .slide-position {
 	display: flex;
 	align-items: center;
-	padding: 0.5rem 0.75rem;
+	padding: 0 0.75rem;
 	font-size: 0.9rem;
 	opacity: 0.8;
 }
@@ -833,7 +841,7 @@ body.playback[data-controls="false"] .playback-start-screen {
 	align-items: center;
 	flex: 0 1 auto;
 	min-width: 0;
-	padding: 0.5rem 0.6rem;
+	padding: 0 0.6rem;
 	border-left: 1px solid rgba(255,255,255,0.1);
 }
 
@@ -856,7 +864,7 @@ body.playback[data-controls="false"] .playback-start-screen {
 	display: flex;
 	align-items: center;
 	margin-left: 0;
-	padding: 0.5rem;
+	padding: 0 0.5rem;
 	border-left: 1px solid rgba(255,255,255,0.1);
 	text-decoration: none;
 	opacity: 0.6;

--- a/releases.md
+++ b/releases.md
@@ -6,6 +6,7 @@
   - Center diagram content by default, add optional diagram titles, and make free-form absolute positioning explicit with `.diagram-freeform`.
   - Prevent slide backgrounds and content from flickering during view transitions.
   - Add lifecycle-managed Anime.js animation scopes, reusable diagram setup scripts, and guidance for authoring animated diagrams.
+  - Truncate long slide paths responsively while preserving their filenames in presenter controls.
 
 ## v0.17.2
 

--- a/test/presently/application.rb
+++ b/test/presently/application.rb
@@ -72,6 +72,17 @@ describe Presently::Application do
 		expect(html.scan('class="preview-frame slide-viewport"').size).to be == 2
 	end
 	
+	it "connects the presenter jump control to its live view" do
+		File.write(File.join(slides_root, "010-example.md"), "---\nmarker: Example\n---\nExample slide\n")
+		
+		response = application.call(request("GET", "/presenter"))
+		html = response.read
+		
+		expect(response.status).to be == 200
+		expect(html).to be(:match?, /<select class="jump-to" data-live-id="[^"]+">/)
+		expect(html).not.to be(:include?, "data-live_id")
+	end
+	
 	it "serves the recording interface separately from the presenter" do
 		response = application.call(request("GET", "/record"))
 		

--- a/test/presently/slide_view.rb
+++ b/test/presently/slide_view.rb
@@ -33,4 +33,28 @@ describe Presently::SlideView do
 			expect(options.dig(:detail, :transition)).to be == "fade"
 		end
 	end
+	
+	with "#render_slide_path" do
+		it "separates the directory from the filename for responsive truncation" do
+			builder = XRB::Builder.new
+			view.render_slide_path(builder, "010-section/020-topic/030-example.md")
+			html = builder.to_s
+			
+			expect(html).to be(:include?, 'title="010-section/020-topic/030-example.md"')
+			expect(html).to be(:include?, 'class="slide-path-directory"')
+			expect(html).to be(:include?, "010-section/020-topic")
+			expect(html).to be(:include?, 'class="slide-path-filename"')
+			expect(html).to be(:include?, "/030-example.md")
+		end
+		
+		it "renders a top-level filename without a separator" do
+			builder = XRB::Builder.new
+			view.render_slide_path(builder, "010-example.md")
+			html = builder.to_s
+			
+			expect(html).not.to be(:include?, "slide-path-directory")
+			expect(html).to be(:include?, 'class="slide-path-filename"')
+			expect(html).to be(:include?, "010-example.md")
+		end
+	end
 end


### PR DESCRIPTION
## Summary

Truncate long slide paths responsively in the presenter and recording controls while preserving the filename and access to the complete path.

## Changes

- Render the directory and filename separately so CSS can place an ellipsis between them when space is constrained.
- Keep the complete path in the title attribute for inspection on hover.
- Share the path rendering between the presenter and recording views.

## Testing

- `bundle exec bake test`
- `bundle exec rubocop`
- `COVERAGE=PartialSummary bundle exec bake decode:index:coverage lib`