### PR TITLE
Remove JRuby and TruffleRuby CI jobs

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -26,12 +26,6 @@ jobs:
         
         include:
           - os: ubuntu
-            ruby: truffleruby
-            experimental: true
-          - os: ubuntu
-            ruby: jruby
-            experimental: true
-          - os: ubuntu
             ruby: head
             experimental: true
     


### PR DESCRIPTION
Remove the experimental JRuby and TruffleRuby entries from the test matrix. Ruby head remains as the experimental compatibility job.

Checks:
- Workflow YAML parses successfully
- 175 tests pass
- RuboCop reports no offenses