### PR TITLE
Reach 100% test coverage

### DIFF
--- a/.github/workflows/test-coverage.yaml
+++ b/.github/workflows/test-coverage.yaml
@@ -55,4 +55,4 @@ jobs:
     
     - name: Validate coverage
       timeout-minutes: 5
-      run: bundle exec bake covered:validate --paths */.covered.db \;
+      run: bundle exec bake covered:validate --minimum 1.0 --paths */.covered.db \;

--- a/test/presently/application.rb
+++ b/test/presently/application.rb
@@ -158,6 +158,11 @@ describe Presently::Application do
 		expect(response.read).to be == "Example slide\n"
 	end
 	
+	it "rejects malformed and missing presentation assets" do
+		expect(application.call(request("GET", "/_slides/%")).status).to be == 404
+		expect(application.call(request("GET", "/_slides/missing.svg")).status).to be == 404
+	end
+	
 	it "only reads presentation assets" do
 		response = application.call(request("POST", "/_slides/010-example.css"))
 		
@@ -186,6 +191,20 @@ describe Presently::Application do
 	it "rejects unsupported recording formats" do
 		response = application.call(request("PUT", "/recordings?index=0", {"content-type" => "audio/mpeg"}, "audio data"))
 		expect(response.status).to be == 415
+	end
+	
+	it "requires a recording body" do
+		response = application.call(request("PUT", "/recordings?index=0", {"content-type" => "audio/webm"}))
+		
+		expect(response.status).to be == 400
+	end
+	
+	it "rejects oversized recordings" do
+		application.instance_variable_set(:@recordings, Presently::Recordings.new(recordings_root, maximum_size: 4))
+		response = application.call(request("PUT", "/recordings?index=0", {"content-type" => "audio/webm"}, "audio data"))
+		
+		expect(response.status).to be == 413
+		expect(response.read).to be(:include?, "4 bytes")
 	end
 	
 	it "rejects an invalid slide index" do
@@ -226,6 +245,19 @@ describe Presently::Application do
 		
 		expect(response.status).to be == 200
 		expect(response.read).to be == "source audio"
+	end
+	
+	it "reports missing narration" do
+		response = application.call(request("GET", "/playback/recordings?index=0"))
+		
+		expect(response.status).to be == 404
+	end
+	
+	it "serves the printable export interface" do
+		response = application.call(request("GET", "/export?notes=true"))
+		
+		expect(response.status).to be == 200
+		expect(response.read).to be(:include?, "Example slide")
 	end
 	
 	it "only reads playback narration" do

--- a/test/presently/display_view.rb
+++ b/test/presently/display_view.rb
@@ -1,0 +1,73 @@
+# frozen_string_literal: true
+
+# Released under the MIT License.
+# Copyright, 2026, by Samuel Williams.
+
+require "presently/display_view"
+require "presently/presentation"
+require "presently/presentation_controller"
+require "tmpdir"
+require "fileutils"
+
+describe Presently::DisplayView do
+	let(:dir) {Dir.mktmpdir}
+	let(:presentation) {Presently::Presentation.load(dir)}
+	let(:controller) {Presently::PresentationController.new(presentation)}
+	let(:view) {subject.root(controller: controller)}
+	let(:updates) {[]}
+	let(:page) do
+		updates = self.updates
+		Object.new.tap do |page|
+			page.define_singleton_method(:enqueue){|update| updates << update}
+		end
+	end
+	
+	before do
+		File.write(File.join(dir, "010-first.md"), "---\ntransition: fade\n---\nFirst slide\n")
+		File.write(File.join(dir, "020-second.md"), "Second slide\n")
+	end
+	
+	after do
+		FileUtils.remove_entry(dir)
+	end
+	
+	it "renders the current slide" do
+		html = view.to_html.to_s
+		
+		expect(html).to be(:include?, "First slide")
+		expect(html).to be(:include?, 'data-transition="fade"')
+		expect(html).to be(:include?, "1 / 2")
+	end
+	
+	it "binds, updates, and closes cleanly" do
+		view.bind(page)
+		expect(updates.last.dig(3, :detail, :transition)).to be == "fade"
+		
+		controller.advance!
+		expect(updates.last.first).to be == :dispatchEvent
+		expect(updates.last.dig(3, :detail, :html)).to be(:include?, "Second slide")
+		
+		view.close
+		expect(view.page).to be_nil
+	end
+	
+	it "handles forward and backward navigation" do
+		view.handle(detail: {action: "next"})
+		expect(controller.current_index).to be == 1
+		
+		view.handle(detail: {action: "previous"})
+		expect(controller.current_index).to be == 0
+	end
+	
+	it "renders nothing when the presentation is empty" do
+		empty = Dir.mktmpdir
+		begin
+			controller = Presently::PresentationController.new(Presently::Presentation.load(empty))
+			view = subject.root(controller: controller)
+			
+			expect(view.to_html.to_s).not.to be(:include?, 'class="display"')
+		ensure
+			FileUtils.remove_entry(empty)
+		end
+	end
+end

--- a/test/presently/environment/application.rb
+++ b/test/presently/environment/application.rb
@@ -21,6 +21,16 @@ describe Presently::Environment::Application do
 		expect(environment.evaluator.application).to be == Presently::Application
 	end
 	
+	it "defaults the slides root relative to the environment root" do
+		environment = Async::Service::Environment.build(
+			Presently::Environment::Application,
+			root: Dir.pwd,
+			endpoint: Async::HTTP::Endpoint.parse("http://localhost:0")
+		)
+		
+		expect(environment.evaluator.slides_root).to be == File.expand_path("slides", Dir.pwd)
+	end
+	
 	# `make_server` comes from `Falcon::Environment::Server`, which this module
 	# does not include directly. Anything wanting to run a server (e.g. the
 	# `presently:export:pdf` task) has to compose the HTTP environment first.

--- a/test/presently/presentation_controller.rb
+++ b/test/presently/presentation_controller.rb
@@ -158,6 +158,34 @@ describe Presently::PresentationController do
 		end
 	end
 	
+	with "#save_state!" do
+		it "saves through the configured state" do
+			saved = nil
+			state = Object.new
+			state.define_singleton_method(:restore){|controller|}
+			state.define_singleton_method(:save){|controller| saved = controller}
+			controller = subject.new(presentation, state: state)
+			
+			controller.save_state!
+			
+			expect(saved).to be == controller
+		end
+	end
+	
+	it "continues notifying listeners when one fails" do
+		failed = Object.new
+		failed.define_singleton_method(:slide_changed!){raise "Failed"}
+		notified = false
+		succeeded = Object.new
+		succeeded.define_singleton_method(:slide_changed!){notified = true}
+		controller.add_listener(failed)
+		controller.add_listener(succeeded)
+		
+		controller.advance!
+		
+		expect(notified).to be == true
+	end
+	
 	with "#reload!" do
 		it "reloads slides and notifies listeners" do
 			notified = false

--- a/test/presently/presenter_view.rb
+++ b/test/presently/presenter_view.rb
@@ -1,0 +1,147 @@
+# frozen_string_literal: true
+
+# Released under the MIT License.
+# Copyright, 2026, by Samuel Williams.
+
+require "presently/presenter_view"
+require "presently/presentation"
+require "presently/presentation_controller"
+require "async"
+require "tmpdir"
+require "fileutils"
+
+describe Presently::PresenterView do
+	let(:dir) {Dir.mktmpdir}
+	let(:presentation) {Presently::Presentation.load(dir)}
+	let(:controller) {Presently::PresentationController.new(presentation)}
+	let(:view) {subject.root(controller: controller)}
+	let(:updates) {[]}
+	let(:page) do
+		updates = self.updates
+		Object.new.tap do |page|
+			page.define_singleton_method(:enqueue){|update| updates << update}
+		end
+	end
+	
+	before do
+		File.write(File.join(dir, "010-first.md"), <<~MARKDOWN)
+			---
+			duration: 30
+			marker: Introduction
+			speaker: Alice
+			---
+			First slide
+
+			---
+
+			First notes
+		MARKDOWN
+		File.write(File.join(dir, "020-second.md"), <<~MARKDOWN)
+			---
+			duration: 45
+			marker: Details
+			speaker: Bob
+			---
+			Second slide
+		MARKDOWN
+	end
+	
+	after do
+		FileUtils.remove_entry(dir)
+	end
+	
+	it "renders previews, notes, timing, speakers, and navigation" do
+		previous_editor = ENV["PRESENTLY_EDITOR"]
+		ENV["PRESENTLY_EDITOR"] = "code"
+		begin
+			html = view.to_html.to_s
+		ensure
+			ENV["PRESENTLY_EDITOR"] = previous_editor
+		end
+		
+		expect(html).to be(:include?, "First slide")
+		expect(html).to be(:include?, "Second slide")
+		expect(html).to be(:include?, "First notes")
+		expect(html).to be(:include?, "▶ Start")
+		expect(html).to be(:include?, "✓ On time")
+		expect(html).to be(:include?, "Alice")
+		expect(html).to be(:include?, "→ Bob")
+		expect(html).to be(:include?, "Jump to…")
+		expect(html).to be(:include?, 'class="edit-link"')
+	end
+	
+	it "renders running, paused, ahead, and behind timing states" do
+		controller.clock.start!
+		running = view.to_html.to_s
+		expect(running).to be(:include?, "⏸ Pause")
+		
+		controller.clock.pause!
+		paused = view.to_html.to_s
+		expect(paused).to be(:include?, "▶ Resume")
+		
+		controller.go_to(1)
+		ahead = view.to_html.to_s
+		expect(ahead).to be(:include?, "⏪ Slow down")
+		expect(ahead).to be(:include?, "No presenter notes")
+		expect(ahead).to be(:include?, "End of presentation")
+		
+		controller.go_to(0)
+		controller.clock.reset!(controller.current_slide.duration + 1)
+		behind = view.to_html.to_s
+		expect(behind).to be(:include?, "⏩ Speed up")
+	end
+	
+	it "binds, updates timing and slides, and closes cleanly" do
+		Sync do
+			view.bind(page)
+			expect(updates.last.first).to be == :replace
+			
+			view.slide_changed!
+			expect(updates.last.first).to be == :dispatchEvent
+			
+			view.close
+			expect(view.page).to be_nil
+		end
+	end
+	
+	it "handles navigation and timing actions" do
+		view.handle(detail: {action: "next"})
+		expect(controller.current_index).to be == 1
+		
+		view.handle(detail: {action: "previous"})
+		expect(controller.current_index).to be == 0
+		
+		view.handle(detail: {action: "pause"})
+		expect(controller.clock).to be(:running?)
+		view.handle(detail: {action: "pause"})
+		expect(controller.clock).to be(:paused?)
+		view.handle(detail: {action: "pause"})
+		expect(controller.clock).to be(:running?)
+		
+		view.handle(detail: {action: "jump", index: "1"})
+		expect(controller.current_index).to be == 1
+		view.handle(detail: {action: "jump"})
+		expect(controller.current_index).to be == 1
+		
+		view.handle(detail: {action: "reset"})
+		expect(controller.clock.elapsed).to be_within(0.1).of(30)
+		
+		view.handle(detail: {action: "reload"})
+		expect(controller.slide_count).to be == 2
+	end
+	
+	it "renders an empty presentation" do
+		empty = Dir.mktmpdir
+		begin
+			controller = Presently::PresentationController.new(Presently::Presentation.load(empty))
+			view = subject.root(controller: controller)
+			html = view.to_html.to_s
+			
+			expect(html).to be(:include?, "End of presentation")
+			expect(html).to be(:include?, "No presenter notes")
+			expect(html).not.to be(:include?, "slide-duration")
+		ensure
+			FileUtils.remove_entry(empty)
+		end
+	end
+end

--- a/test/presently/recording_view.rb
+++ b/test/presently/recording_view.rb
@@ -33,7 +33,13 @@ describe Presently::RecordingView do
 	end
 	
 	it "renders a dedicated recording interface" do
-		html = Presently::Page.new(body: view).to_html
+		previous_editor = ENV["PRESENTLY_EDITOR"]
+		ENV["PRESENTLY_EDITOR"] = "code"
+		begin
+			html = Presently::Page.new(body: view).to_html
+		ensure
+			ENV["PRESENTLY_EDITOR"] = previous_editor
+		end
 		
 		expect(html).to be(:include?, "Example slide")
 		expect(html).to be(:include?, "Narrate this slide.")
@@ -44,6 +50,7 @@ describe Presently::RecordingView do
 		expect(html).to be(:include?, "● Record")
 		expect(html).not.to be(:include?, 'class="recording-stop"')
 		expect(html).to be(:include?, 'class="recording-indicator"')
+		expect(html).to be(:include?, 'class="edit-link"')
 	end
 	
 	it "navigates independently of the presenter interface" do

--- a/test/presently/recording_view.rb
+++ b/test/presently/recording_view.rb
@@ -16,6 +16,13 @@ describe Presently::RecordingView do
 	let(:presentation) {Presently::Presentation.load(dir)}
 	let(:controller) {Presently::PresentationController.new(presentation)}
 	let(:view) {subject.root(controller: controller)}
+	let(:updates) {[]}
+	let(:page) do
+		updates = self.updates
+		Object.new.tap do |page|
+			page.define_singleton_method(:enqueue){|update| updates << update}
+		end
+	end
 	
 	before do
 		File.write(path, "---\nmarker: Example\n---\nExample slide\n\n---\nNarrate this slide.\n")
@@ -45,5 +52,46 @@ describe Presently::RecordingView do
 		
 		view.handle(detail: {action: "next"})
 		expect(controller.current_index).to be == 1
+	end
+	
+	it "binds, updates, and closes cleanly" do
+		view.bind(page)
+		view.slide_changed!
+		expect(updates.last.first).to be == :dispatchEvent
+		
+		view.close
+		expect(view.page).to be_nil
+	end
+	
+	it "handles all navigation actions" do
+		File.write(File.join(dir, "020-next.md"), "Next slide\n")
+		controller.reload!
+		
+		view.handle(detail: {action: "next"})
+		expect(controller.current_index).to be == 1
+		view.handle(detail: {action: "previous"})
+		expect(controller.current_index).to be == 0
+		view.handle(detail: {action: "jump", index: "1"})
+		expect(controller.current_index).to be == 1
+		view.handle(detail: {action: "jump"})
+		expect(controller.current_index).to be == 1
+		view.handle(detail: {action: "reload"})
+		expect(controller.slide_count).to be == 2
+	end
+	
+	it "renders a slide without notes or markers" do
+		File.write(path, "Example slide\n")
+		controller.reload!
+		html = Presently::Page.new(body: view).to_html
+		
+		expect(html).to be(:include?, "No presenter notes")
+		expect(html).not.to be(:include?, "Jump to…")
+	end
+	
+	it "renders nothing when the presentation is empty" do
+		File.unlink(path)
+		controller.reload!
+		
+		expect(view.to_html.to_s).not.to be(:include?, 'class="recorder"')
 	end
 end

--- a/test/presently/slide_assets.rb
+++ b/test/presently/slide_assets.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+# Released under the MIT License.
+# Copyright, 2026, by Samuel Williams.
+
+require "presently/slide_assets"
+require "protocol/http/middleware"
+require "tmpdir"
+require "fileutils"
+
+describe Presently::SlideAssets do
+	let(:dir) {Dir.mktmpdir}
+	let(:assets) do
+		subject.new(
+			Protocol::HTTP::Middleware::NotFound,
+			root: dir,
+			stylesheets: ->{[]},
+		)
+	end
+	
+	after do
+		FileUtils.remove_entry(dir)
+	end
+	
+	it "handles an invalid request path" do
+		request = Struct.new(:path).new(Object.new)
+		
+		expect(assets.send(:request_path, request)).to be_nil
+	end
+end

--- a/test/presently/slide_renderer.rb
+++ b/test/presently/slide_renderer.rb
@@ -33,6 +33,10 @@ describe Presently::TemplateScope do
 			expect(scope.section("title")).to be(:include?, "Hello World")
 		end
 		
+		it "exposes the slide content" do
+			expect(scope.content).to be == slide.content
+		end
+		
 		it "returns true for section? when section exists" do
 			expect(scope.section?("title")).to be_truthy
 		end
@@ -131,5 +135,22 @@ describe Presently::SlideRenderer do
 		expect(html.scan('type="text/slide-script"').size).to be == 2
 		expect(html).to be(:include?, "globalThis.setup")
 		expect(html).to be(:include?, "globalThis.control")
+	end
+	
+	it "renders translation content" do
+		File.write(path, "Example slide\n\n# Translation\n\nTranslated slide\n")
+		presentation = Presently::Presentation.load(dir)
+		html = subject.new(templates: presentation.templates).render_to_html(presentation.slides.first)
+		
+		expect(html).to be(:include?, 'class="slide-translation"')
+		expect(html).to be(:include?, "Translated slide")
+	end
+end
+
+describe Presently::Templates do
+	it "raises a useful error for a missing template" do
+		templates = subject.new([])
+		
+		expect{templates.resolve("missing")}.to raise_exception(Errno::ENOENT, message: be(:include?, "Template 'missing' not found"))
 	end
 end

--- a/test/presently/state.rb
+++ b/test/presently/state.rb
@@ -68,6 +68,21 @@ describe Presently::State do
 			state.restore(controller)
 			expect(controller.current_index).to be == 0
 		end
+		
+		it "handles save failures gracefully" do
+			state = subject.new(File.join(dir, "missing", "state.json"))
+			controller = Presently::PresentationController.new(presentation)
+			
+			expect(state.save(controller)).to be_nil
+		end
+		
+		it "handles malformed state gracefully" do
+			File.write(path, "not json")
+			controller = Presently::PresentationController.new(presentation)
+			
+			expect(state.restore(controller)).to be_nil
+			expect(controller.current_index).to be == 0
+		end
 	end
 	
 	with "auto-save via controller" do


### PR DESCRIPTION
## Summary

- Add focused coverage for application routes, live view lifecycles and actions, persistence failures, templates, assets, and environment defaults.
- Require 100% aggregate coverage in the coverage workflow.

## Testing

- `COVERAGE=PartialSummary bundle exec bake test` (202 tests, 343 assertions, 1047/1047 lines)
- `bundle exec bake covered:validate --minimum 1.0 --paths .covered.db`
- `bundle exec rubocop`
- `npm test`
- `bundle exec bake web:packages:check`