### PR TITLE
Preserve state during controller restoration

### DIFF
--- a/lib/presently/presentation_controller.rb
+++ b/lib/presently/presentation_controller.rb
@@ -3,6 +3,8 @@
 # Released under the MIT License.
 # Copyright, 2026, by Samuel Williams.
 
+require "console"
+
 require_relative "clock"
 require_relative "presentation"
 require_relative "state"
@@ -21,9 +23,9 @@ module Presently
 			@current_index = 0
 			@clock = Clock.new
 			@listeners = []
-			@state = state
 			
-			@state&.restore(self)
+			state&.restore(self)
+			@state = state
 		end
 		
 		# @attribute [Presentation] The underlying presentation data.

--- a/lib/presently/state.rb
+++ b/lib/presently/state.rb
@@ -3,6 +3,7 @@
 # Released under the MIT License.
 # Copyright, 2026, by Samuel Williams.
 
+require "console"
 require "json"
 
 module Presently

--- a/releases.md
+++ b/releases.md
@@ -7,6 +7,7 @@
   - Prevent slide backgrounds and content from flickering during view transitions.
   - Add lifecycle-managed Anime.js animation scopes, reusable diagram setup scripts, and guidance for authoring animated diagrams.
   - Truncate long slide paths responsively while preserving their filenames in presenter controls.
+  - Preserve the complete saved presentation state when restoring the controller.
 
 ## v0.17.2
 

--- a/test/presently/state.rb
+++ b/test/presently/state.rb
@@ -103,5 +103,19 @@ describe Presently::State do
 			restored = Presently::PresentationController.new(presentation, state: state)
 			expect(restored.current_index).to be == 4
 		end
+		
+		it "does not overwrite state while restoring it" do
+			controller = Presently::PresentationController.new(presentation, state: state)
+			controller.go_to(4)
+			controller.clock.restore!(120.0, running: false)
+			controller.save_state!
+			saved = File.read(path)
+			
+			restored = Presently::PresentationController.new(presentation, state: state)
+			
+			expect(restored.current_index).to be == 4
+			expect(restored.clock.elapsed).to be == 120.0
+			expect(File.read(path)).to be == saved
+		end
 	end
 end


### PR DESCRIPTION
## Summary

Fix controller restoration so that loading a saved slide position does not trigger an intermediate save before the clock state has been restored. Persistence is now attached only after restoration completes.

Add explicit `console` requirements for the warning paths used by the controller and state classes.

## Testing

- `bundle exec sus test/presently/state.rb`
- `bundle exec sus test/presently/presentation_controller.rb`
- `COVERAGE=PartialSummary bundle exec bake test`
- `bundle exec bake covered:validate --minimum 1.0 --paths .covered.db`
- `bundle exec rubocop`
- `git diff --check`