### PR TITLE
Support language-prefixed inline code

### DIFF
--- a/lib/presently/slide.rb
+++ b/lib/presently/slide.rb
@@ -72,7 +72,7 @@ module Presently
 				raw = File.read(source_path)
 				
 				# Parse once, with native front matter support.
-				document = Markly.parse(raw, flags: Markly::UNSAFE | Markly::FRONT_MATTER, extensions: Fragment::EXTENSIONS)
+				document = Markly.parse(raw, flags: Markly::UNSAFE | Markly::FRONT_MATTER | Markly::INLINE_CODE_INFO, extensions: Fragment::EXTENSIONS)
 				
 				expand_includes!(document, File.dirname(source_path), presentation.root)
 				rewrite_image_urls!(document, source_path, presentation.root)
@@ -169,7 +169,7 @@ module Presently
 				to_replace.each do |paragraph, relative_path|
 					included_path = File.expand_path(relative_path, base_dir)
 					included_raw = File.read(included_path)
-					included_document = Markly.parse(included_raw, flags: Markly::UNSAFE | Markly::FRONT_MATTER, extensions: Fragment::EXTENSIONS)
+					included_document = Markly.parse(included_raw, flags: Markly::UNSAFE | Markly::FRONT_MATTER | Markly::INLINE_CODE_INFO, extensions: Fragment::EXTENSIONS)
 					
 					# Strip front matter from included file if present.
 					front_matter_node = included_document.first_child

--- a/presently.gemspec
+++ b/presently.gemspec
@@ -28,7 +28,7 @@ Gem::Specification.new do |spec|
 	
 	spec.add_dependency "lively", "~> 0.22"
 	spec.add_dependency "live", "~> 0.21"
-	spec.add_dependency "markly", "~> 0.16"
+	spec.add_dependency "markly", "~> 0.18"
 	spec.add_dependency "async-webdriver", "~> 0.12"
 	spec.add_dependency "protocol-media-registry", "~> 0.0"
 end

--- a/releases.md
+++ b/releases.md
@@ -1,5 +1,9 @@
 # Releases
 
+## Unreleased
+
+  - Support language-prefixed inline code such as `ruby:` for syntax highlighting.
+
 ## v0.18.0
 
   - Render slides on a responsive 16:9 canvas across the display, presenter, recording, playback, and export interfaces.

--- a/test/presently/slide.rb
+++ b/test/presently/slide.rb
@@ -280,6 +280,27 @@ describe Presently::Slide do
 		end
 	end
 	
+	with "inline code language prefixes" do
+		let(:dir) {Dir.mktmpdir}
+		let(:path) {File.join(dir, "main.md")}
+		
+		before do
+			File.write(path, "Call ruby:`Object.new` to create an object.\n")
+		end
+		
+		after do
+			FileUtils.remove_entry(dir)
+		end
+		
+		let(:slide) {load_slide(path)}
+		
+		it "renders the language as a class" do
+			html = slide.content["body"].to_html
+			expect(html).to be(:include?, '<code class="language-ruby">Object.new</code>')
+			expect(html).not.to be(:include?, "ruby:")
+		end
+	end
+	
 	with "a slide with a nested ![[include]] directive" do
 		let(:dir) {Dir.mktmpdir}
 		let(:path) {File.join(dir, "main.md")}
@@ -287,7 +308,7 @@ describe Presently::Slide do
 		let(:inner_path) {File.join(dir, "inner.md")}
 		
 		before do
-			File.write(inner_path, "Deeply nested content.\n")
+			File.write(inner_path, "Deeply nested ruby:`Object.new` content.\n")
 			File.write(middle_path, "Middle content.\n\n![[inner.md]]\n")
 			File.write(path, "![[middle.md]]\n")
 		end
@@ -301,7 +322,8 @@ describe Presently::Slide do
 		it "recursively expands nested includes" do
 			html = slide.content["body"].to_html
 			expect(html).to be(:include?, "Middle content")
-			expect(html).to be(:include?, "Deeply nested content")
+			expect(html).to be(:include?, "Deeply nested")
+			expect(html).to be(:include?, '<code class="language-ruby">Object.new</code>')
 		end
 	end
 	


### PR DESCRIPTION
## Summary

Enable Markly inline code language metadata when parsing slides and included Markdown. This allows syntax such as ruby:`Object.new` to render with a language-ruby class for syntax highlighting.

Require Markly v0.18 so metadata is retained while Presently duplicates AST nodes during include expansion and section extraction.

## Validation

- 204 tests pass with 350 assertions
- 100% code coverage
- 100% documentation coverage
- RuboCop passes