### PR TITLE
Preserve blank lines in HTML blocks

### DIFF
--- a/lib/presently/slide.rb
+++ b/lib/presently/slide.rb
@@ -72,7 +72,7 @@ module Presently
 				raw = File.read(source_path)
 				
 				# Parse once, with native front matter support.
-				document = Markly.parse(raw, flags: Markly::UNSAFE | Markly::FRONT_MATTER | Markly::INLINE_CODE_INFO, extensions: Fragment::EXTENSIONS)
+				document = Markly.parse(raw, flags: Markly::UNSAFE | Markly::FRONT_MATTER | Markly::INLINE_CODE_INFO | Markly::HTML_BLOCK_BLANK_LINES, extensions: Fragment::EXTENSIONS)
 				
 				expand_includes!(document, File.dirname(source_path), presentation.root)
 				rewrite_image_urls!(document, source_path, presentation.root)
@@ -169,7 +169,7 @@ module Presently
 				to_replace.each do |paragraph, relative_path|
 					included_path = File.expand_path(relative_path, base_dir)
 					included_raw = File.read(included_path)
-					included_document = Markly.parse(included_raw, flags: Markly::UNSAFE | Markly::FRONT_MATTER | Markly::INLINE_CODE_INFO, extensions: Fragment::EXTENSIONS)
+					included_document = Markly.parse(included_raw, flags: Markly::UNSAFE | Markly::FRONT_MATTER | Markly::INLINE_CODE_INFO | Markly::HTML_BLOCK_BLANK_LINES, extensions: Fragment::EXTENSIONS)
 					
 					# Strip front matter from included file if present.
 					front_matter_node = included_document.first_child

--- a/presently.gemspec
+++ b/presently.gemspec
@@ -28,7 +28,7 @@ Gem::Specification.new do |spec|
 	
 	spec.add_dependency "lively", "~> 0.22"
 	spec.add_dependency "live", "~> 0.21"
-	spec.add_dependency "markly", "~> 0.18"
+	spec.add_dependency "markly", "~> 0.19"
 	spec.add_dependency "async-webdriver", "~> 0.12"
 	spec.add_dependency "protocol-media-registry", "~> 0.0"
 end

--- a/releases.md
+++ b/releases.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
   - Support language-prefixed inline code such as `ruby:` for syntax highlighting.
+  - Preserve blank lines within consistently indented HTML blocks in slide Markdown.
 
 ## v0.18.0
 

--- a/test/presently/slide.rb
+++ b/test/presently/slide.rb
@@ -301,6 +301,45 @@ describe Presently::Slide do
 		end
 	end
 	
+	with "blank lines in HTML blocks" do
+		let(:dir) {Dir.mktmpdir}
+		let(:path) {File.join(dir, "main.md")}
+		let(:slide) {load_slide(path)}
+		let(:html) {slide.content["body"].to_html}
+		
+		after do
+			FileUtils.remove_entry(dir)
+		end
+		
+		it "preserves consistently indented slide HTML" do
+			File.write(path, <<~MARKDOWN)
+				<div class="diagram">
+					<div class="first">First</div>
+					
+					<div class="second">Second</div>
+				</div>
+			MARKDOWN
+			
+			expect(html).to be(:include?, '<div class="second">Second</div>')
+			expect(html).not.to be(:include?, "<pre><code>")
+		end
+		
+		it "preserves consistently indented included HTML" do
+			included_path = File.join(dir, "diagram.md")
+			File.write(included_path, <<~MARKDOWN)
+				<div class="diagram">
+					<div class="first">First</div>
+					
+					<div class="second">Second</div>
+				</div>
+			MARKDOWN
+			File.write(path, "![[diagram.md]]\n")
+			
+			expect(html).to be(:include?, '<div class="second">Second</div>')
+			expect(html).not.to be(:include?, "<pre><code>")
+		end
+	end
+	
 	with "a slide with a nested ![[include]] directive" do
 		let(:dir) {Dir.mktmpdir}
 		let(:path) {File.join(dir, "main.md")}


### PR DESCRIPTION
## Summary

Update to Markly v0.19 and enable `Markly::HTML_BLOCK_BLANK_LINES` when parsing slides and included Markdown. This keeps consistently indented HTML together across blank lines, making larger slide diagrams easier to format and maintain.

## Validation

- Added regression coverage for direct slide HTML and included HTML
- 206 tests, 354 assertions
- RuboCop passes
- 100% documentation coverage
- Unsigned gem build succeeds