### PR TITLE
Keep delayed animations within slide scope

### DIFF
--- a/components/presently/Presently/Slide.js
+++ b/components/presently/Presently/Slide.js
@@ -315,7 +315,13 @@ export class Slide {
 	setTimeout(callback, delay) {
 		if (this.#disposed) return null;
 
-		const timeoutId = window.setTimeout(callback, delay);
+		const timeoutId = window.setTimeout(() => {
+			if (this.#animeScope) {
+				this.#animeScope.execute(() => callback());
+			} else {
+				callback();
+			}
+		}, delay);
 		this.#timeouts.push(timeoutId);
 		return timeoutId;
 	}

--- a/components/presently/test/Slide.js
+++ b/components/presently/test/Slide.js
@@ -77,6 +77,29 @@ test('manages a slide-scoped Anime.js scope', () => {
 	assert.equal(lateCleanup, true);
 });
 
+test('keeps delayed Anime.js resources within the slide scope', async () => {
+	const slide = new Slide(new FakeElement());
+	let complete;
+	const completed = new Promise(resolve => complete = resolve);
+	let cleaned = false;
+	let callbackArguments = null;
+
+	slide.anime((anime) => {
+		slide.setTimeout((...arguments_) => {
+			callbackArguments = arguments_;
+			const nestedScope = anime.createScope();
+			nestedScope.add(() => () => cleaned = true);
+			complete();
+		}, 0);
+	});
+
+	await completed;
+	slide.dispose();
+
+	assert.deepEqual(callbackArguments, []);
+	assert.equal(cleaned, true);
+});
+
 test('disables animation when reduced motion is preferred', () => {
 	const matchMedia = window.matchMedia;
 	window.matchMedia = () => ({matches: true});

--- a/context/animating-slides.md
+++ b/context/animating-slides.md
@@ -240,6 +240,8 @@ slide.anime(({createTimeline, stagger}) => {
 
 The callback receives the Anime.js module API and runs inside a scope rooted at the slide body. Selectors cannot match elements in another slide. Presently reuses the scope across calls and automatically invokes `scope.revert()` when the slide is deactivated.
 
+Tracked delayed callbacks automatically re-enter this scope, so Anime.js resources created inside `slide.setTimeout()`, `slide.after()`, `slide.loop()`, or the script-local `setTimeout()` are also reverted with the slide.
+
 `slide.animated` is false during static export and when the browser requests reduced motion. Configure timelines not to autoplay or loop in that case, then seek to a meaningful static frame.
 
 See [Animated Diagrams](../animated-diagrams/) for layout, choreography, accessibility, and agent-authoring guidance.

--- a/public/_components/.manifest.json
+++ b/public/_components/.manifest.json
@@ -14,7 +14,7 @@
         "Presently.js": "552a41737db0e67cde2f4555cf686ddb6a5de8da28c64d0404b8d7b2c10152c9",
         "Presently/CodeFocus.js": "05fb95308f012cab92655671050279149fc4aa683450932e27fc77bd51f8ce29",
         "Presently/Scripts.js": "c8f01508021038220ab7a2eec9cffc92d7c0f2d4bd57d928dcc88c748e6469a9",
-        "Presently/Slide.js": "5ed6b31d2373ce1944ea4c24773da82291e8a538802003a32736f430b8854baf",
+        "Presently/Slide.js": "0d67e83eff558aee8ae829a2e526dc4d583f9c0753db156c531b57e32d271ead",
         "Presently/SlideRendering.js": "2bb1ad46bab648731744307fc4bd845b706e1592acb0ac68d6babb941c63388d"
       }
     },
@@ -126,5 +126,5 @@
       }
     }
   },
-  "digest": "a4a80ca4697630635f826f3044f43152fd14c1cb18fb4404fd89080bc7d15dc5"
+  "digest": "f06b63693c5af593d2c7c4947bae9a16a2c7ca0d4e5e257e10dded909ffef4a7"
 }

--- a/public/_components/@socketry/presently/Presently/Slide.js
+++ b/public/_components/@socketry/presently/Presently/Slide.js
@@ -315,7 +315,13 @@ export class Slide {
 	setTimeout(callback, delay) {
 		if (this.#disposed) return null;
 
-		const timeoutId = window.setTimeout(callback, delay);
+		const timeoutId = window.setTimeout(() => {
+			if (this.#animeScope) {
+				this.#animeScope.execute(() => callback());
+			} else {
+				callback();
+			}
+		}, delay);
 		this.#timeouts.push(timeoutId);
 		return timeoutId;
 	}

--- a/releases.md
+++ b/releases.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+  - Keep Anime.js resources created by delayed slide callbacks bound to the slide lifecycle.
   - Support language-prefixed inline code such as `ruby:` for syntax highlighting.
   - Preserve blank lines within consistently indented HTML blocks in slide Markdown.
 


### PR DESCRIPTION
## Summary

Ensure Anime.js resources created by tracked delayed callbacks remain registered with the active slide scope. This covers `slide.setTimeout`, `slide.after`, `slide.loop`, builders, and the script-local `setTimeout`.

Add a regression test proving a delayed nested Anime scope is reverted when the slide is disposed, document the lifecycle guarantee, and update the generated browser package projection.

## Testing

- `npm test`
- `bundle exec bake test`
- `bundle exec bake web:packages:check`
- `bundle exec rubocop`
- `COVERAGE=PartialSummary bundle exec bake decode:index:coverage lib`