### PR TITLE
Keep presenter toolbar within viewport

### DIFF
--- a/public/_static/index.css
+++ b/public/_static/index.css
@@ -760,6 +760,7 @@ body.playback[data-controls="false"] .playback-start-screen {
 	display: flex;
 	align-items: center;
 	gap: 1rem;
+	min-width: 0;
 }
 
 .toolbar > button,

--- a/releases.md
+++ b/releases.md
@@ -1,5 +1,9 @@
 # Releases
 
+## Unreleased
+
+  - Keep presenter toolbars within the viewport when slide paths are long.
+
 ## v0.19.0
 
   - Keep Anime.js resources created by delayed slide callbacks bound to the slide lifecycle.


### PR DESCRIPTION
## Summary

Allow shared toolbars to shrink within the presenter grid so long slide paths are truncated instead of widening the page.

## Verification

- Reproduced the overflow at a 1512×982 CSS viewport (3024×1964 Retina).
- Confirmed the toolbar remains within the viewport after the change.
- `bundle exec bake test`
- `bundle exec rubocop`
- `npm test`